### PR TITLE
Fix travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/codebytere/trop.svg)](https://travis-ci.org/codebytere/trop)
+[![Build Status](https://img.shields.io/travis/electron/trop.svg)](https://travis-ci.org/electron/trop)
 
 # trop
 


### PR DESCRIPTION
Migrate travis builds to the `electron` [org](https://travis-ci.org/electron/trop) and update badge to reflect that.

/cc @ckerr @MarshallOfSound 