### PR TITLE
fix: make backport PR titles semantic

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "pify": "^3.0.0",
     "probot": "^6.0.0",
     "randomcolor": "^0.5.3",
-    "simple-git": "^1.92.0"
+    "simple-git": "1.92.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.16.8",
     "@types/express": "^4.11.1",
     "@types/fs-extra": "^5.0.1",
-    "@types/node": "^9.4.7",
-    "@types/node-fetch": "^1.6.7",
+    "@types/node": "^10.5.2",
+    "@types/node-fetch": "^2.1.1",
     "@types/pify": "^3.0.1",
-    "jest": "^21.2.1",
+    "jest": "^23.4.0",
     "smee-client": "^1.0.1",
-    "standard": "^10.0.3",
+    "standard": "^11.0.1",
     "typescript": "^2.7.2"
   },
   "engines": {

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -197,7 +197,7 @@ const backportImpl = async (robot: Probot,
     const newPr = (await context.github.pullRequests.create(context.repo({
       head: `${fork.owner.login}:${tempBranch}`,
       base: targetBranch,
-      title: `Backport (${targetBranch}) - ${pr.title}`,
+      title: `${pr.title} (backport: ${targetBranch})`,
       body: createBackportComment(pr),
       maintainer_can_modify: false,
     }))).data;
@@ -253,7 +253,7 @@ export const backportToLabel = async (robot: Probot, context: ProbotContext<Pull
     return;
   }
 
-  const targetBranch = labelToTargetBranch(label, labelPrefixes.target);  
+  const targetBranch = labelToTargetBranch(label, labelPrefixes.target);
   if (!targetBranch) {
     robot.log('Nothing to do');
     return;


### PR DESCRIPTION
This PR makes trop's generated PR titles semantic for changelog purposes.

/cc @MarshallOfSound @ckerr @jkleinsc 