### PR TITLE
feat: allow triggering multiple backports in same comment

### DIFF
--- a/spec/fixtures/issue_comment_backport_to_multiple.created.json
+++ b/spec/fixtures/issue_comment_backport_to_multiple.created.json
@@ -1,0 +1,42 @@
+{
+  "event": "issue_comment",
+  "payload": {
+    "action": "created",
+    "issue": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pull/1234",
+      "html_url": "https://github.com/codebytere/public-repo/pull/1234",
+      "number": 1234,
+      "title": "Spelling error in the README file",
+      "user": {
+        "login": "codebytere"
+      },
+      "labels": [
+        {
+          "url": "https://api.github.com/repos/codebytere/public-repo/labels/target/X-X-X",
+          "name": "target/X-X-X",
+          "color": "fc2929"
+        }
+      ],
+      "body": "It looks like you accidently spelled 'commit' with two 't's."
+    },
+    "comment": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pulls/comments/123456789",
+      "html_url": "https://github.com/codebytere/public-repo/pulls/2#issuecomment-123456789",
+      "id": 99262140,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "/trop run backport-to thingy1,thingy2"
+    },
+    "repository": {
+      "name": "public-repo",
+      "full_name": "codebytere/public-repo",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -54,7 +54,6 @@ const backportImpl = async (robot: Probot,
                             labelToRemove?: string,
                             labelToAdd?: string) => {
   const base = context.payload.pull_request.base;
-  const head = context.payload.pull_request.base;
   const slug = `${base.repo.owner.login}/${base.repo.name}`;
   const bp = `backport from PR #${context.payload.pull_request.number} to "${targetBranch}"`;
   robot.log(`Queuing ${bp} for "${slug}"`);

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,9 @@ module.exports = async (robot) => {
       command: /^run backport-to ([^\s:]+)/,
       execute: async (targetBranches) => {
         const branches = targetBranches.split(',')
-        for (const branch in branches) {
+        for (const branch of branches) {
+          console.log(branch)
+          if (!(branch.trim())) continue
           robot.log(`backport-to ${branch}`)
           const pr = (await context.github.pullRequests.get(context.repo({number: payload.issue.number}))).data
           try {

--- a/src/index.js
+++ b/src/index.js
@@ -76,10 +76,11 @@ module.exports = async (robot) => {
       execute: async (targetBranches) => {
         const branches = targetBranches.split(',')
         for (const branch of branches) {
-          console.log(branch)
-          if (!(branch.trim())) continue
           robot.log(`backport-to ${branch}`)
+
+          if (!(branch.trim())) continue
           const pr = (await context.github.pullRequests.get(context.repo({number: payload.issue.number}))).data
+
           try {
             (await context.github.repos.getBranch(context.repo({branch})))
           } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -73,26 +73,27 @@ module.exports = async (robot) => {
     }, {
       name: 'backport to branch',
       command: /^run backport-to ([^\s:]+)/,
-      execute: async (targetBranch) => {
-        robot.log(`backport-to ${targetBranch}`)
-        const pr = (await context.github.pullRequests.get(context.repo({number: payload.issue.number}))).data
-        try {
-          (await context.github.repos.getBranch(context.repo({
-            branch: targetBranch
-          })))
-        } catch (err) {
+      execute: async (targetBranches) => {
+        const branches = targetBranches.split(',')
+        for (const branch in branches) {
+          robot.log(`backport-to ${branch}`)
+          const pr = (await context.github.pullRequests.get(context.repo({number: payload.issue.number}))).data
+          try {
+            (await context.github.repos.getBranch(context.repo({branch})))
+          } catch (err) {
+            await context.github.issues.createComment(context.repo({
+              number: payload.issue.number,
+              body: `The branch you provided "${branch}" does not appear to exist :cry:`
+            }))
+            return true
+          }
           await context.github.issues.createComment(context.repo({
             number: payload.issue.number,
-            body: `The branch you provided "${targetBranch}" does not appear to exist :cry:`
+            body: `The backport process for this PR has been manually initiated, sending your 1's and 0's to "${branch}" here we go! :D`
           }))
-          return true
+          context.payload.pull_request = context.payload.pull_request || pr
+          backportToBranch(robot, context, branch)
         }
-        await context.github.issues.createComment(context.repo({
-          number: payload.issue.number,
-          body: `The backport process for this PR has been manually initiated, sending your 1's and 0's to "${targetBranch}" here we go! :D`
-        }))
-        context.payload.pull_request = context.payload.pull_request || pr
-        backportToBranch(robot, context, targetBranch)
         return true
       }
     }]


### PR DESCRIPTION
This PR allows for multiple PRs to be triggered in a single comment of the following format:
`/trop run backport-to 3-0-x,2-0-x`, where the target branches are comma-separated with no space. 

Todo:
- [x] add spec

/cc @MarshallOfSound @ckerr