### PR TITLE
feat: add PR release notes to backport PR body

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -40,10 +40,20 @@ const tellRunnerTo = async (what: string, payload: any) => {
 const createBackportComment = (pr: PullRequest) => {
   let body = `Backport of #${pr.number}\n\nSee that PR for details.`;
 
-  const re = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) (${pr.base.repo.html_url}/issues/\\d+)`, 'i');
-  const match = pr.body.match(re);
-  if (Array.isArray(match) && match.length>1)
-    body += '\n\n' + match[0];
+  const issueFixInfo = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) (${pr.base.repo.html_url}/issues/\\d+)`, 'i');
+  const issueMatch = pr.body.match(issueFixInfo);
+
+  const notesInfo = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
+  const notesMatch = pr.body.match(notesInfo);
+
+  // attach information about issues resolved, if any
+  if (Array.isArray(issueMatch) && issueMatch.length > 1) {
+    body += `\n\n ${issueMatch[0]}`;
+  }
+
+  // PRs can't be merged without notes, 
+  // so we can assume this match will exist
+  body += `\n\n ${notesMatch}`;
 
   return body;
 }

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -43,17 +43,20 @@ const createBackportComment = (pr: PullRequest) => {
   const issueFixInfo = new RegExp(`(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) (${pr.base.repo.html_url}/issues/\\d+)`, 'i');
   const issueMatch = pr.body.match(issueFixInfo);
 
-  const notesInfo = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
-  const notesMatch = pr.body.match(notesInfo);
-
   // attach information about issues resolved, if any
   if (Array.isArray(issueMatch) && issueMatch.length > 1) {
     body += `\n\n ${issueMatch[0]}`;
   }
 
-  // PRs can't be merged without notes, 
-  // so we can assume this match will exist
-  body += `\n\n ${notesMatch}`;
+  const notesInfo = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
+  const notesMatch = pr.body.match(notesInfo);
+
+  // attach release notes to backport PR body
+  if (Array.isArray(notesMatch) && notesMatch.length > 1) {
+    body += `\n\n ${notesMatch}`;
+  } else {
+    body += '\n\n notes: no-notes';
+  }
 
   return body;
 }


### PR DESCRIPTION
Resolves https://github.com/electron/trop/issues/41.

This PR also checks a given PR body for release notes and adds them to the backport PR body, such that trop's PRs will comply with the new `release-notes` check. 

/cc @MarshallOfSound 