### PR TITLE
fix: incorrect no-notes being appended

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -39,15 +39,15 @@ const createBackportComment = (pr: PullRequest) => {
 
   // attach information about issues resolved, if any
   if (Array.isArray(issueMatch) && issueMatch.length > 1) {
-    body += `\n\n ${issueMatch[0]}`;
+    body += `\n\n${issueMatch[0]}`;
   }
 
   const notesInfo = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
   const notesMatch = pr.body.match(notesInfo);
 
   // attach release notes to backport PR body
-  if (Array.isArray(notesMatch) && notesMatch.length > 1) {
-    body += `\n\n ${notesMatch}`;
+  if (Array.isArray(notesMatch) && notesMatch.length >= 1) {
+    body += `\n\n${notesMatch}`;
   } else {
     body += '\n\nNotes: no-notes';
   }


### PR DESCRIPTION
Resolves an issue whereby `Notes: no-notes` was being erroneously appended to generated PR bodies that had actual release notes.

See: https://github.com/electron/electron/pull/14823 and its associated backports to `3-0-x`/`2-0-x`

/cc @MarshallOfSound 