### PR TITLE
feat: allow multiline release notes

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -42,12 +42,15 @@ const createBackportComment = (pr: PullRequest) => {
     body += `\n\n${issueMatch[0]}`;
   }
 
-  const notesInfo = new RegExp(`(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)`, 'gi');
-  const notesMatch = pr.body.match(notesInfo);
+  const onelineMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(pr.body);
+  const multilineMatch =
+      /(?:(?:\r?\n)Notes:(?:\r?\n)((?:\*.+(?:(?:\r?\n)|$))+))/gi.exec(pr.body);
 
   // attach release notes to backport PR body
-  if (Array.isArray(notesMatch) && notesMatch.length >= 1) {
-    body += `\n\n${notesMatch}`;
+  if (onelineMatch && onelineMatch[1]) {
+    body += `\n\n${onelineMatch[1]}`;
+  } else if (multilineMatch && multilineMatch[1]) {
+    body += `\n\n${multilineMatch[1]}`;
   } else {
     body += '\n\nNotes: no-notes';
   }


### PR DESCRIPTION
Allow backporting of multi-line release notes in concert with https://github.com/electron/clerk/pull/16.

/cc @MarshallOfSound