### PR TITLE
fix: add explicit bp error comment

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -321,6 +321,15 @@ export const backportImpl = async (robot: Application,
         await fs.remove(createdDir);
       }
 
+      const pr = context.payload.pull_request;
+      if (purpose === BackportPurpose.ExecuteBackport) {
+        await context.github.issues.createComment(context.repo({
+          number: pr.number,
+          body: `I was unable to backport this PR to "${targetBranch}" cleanly;
+   you will need to perform this backport manually.`,
+        }) as any);
+      }
+
       if (purpose === BackportPurpose.Check) {
         const checkRun = await getCheckRun();
         if (checkRun) {


### PR DESCRIPTION
When backports fail, Trop once again will post an explicit comment to that effect.

/cc @alexeykuzmin