### PR TITLE
feat: label backport PRs with target branch

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -265,7 +265,7 @@ export const backportImpl = async (robot: Application,
 
         await context.github.issues.addLabels(context.repo({
           number: newPr.number!,
-          labels: ['backport'],
+          labels: ['backport', `${targetBranch}`],
         }));
 
         log('Backport complete');


### PR DESCRIPTION
At the moment it's impossible to sort PRs by their target branch, so this PR enables trop to tag backport PRs with labels corresponding to the target branch (one of `['4-0-x', '3-0-x', '2-0-x', '1-8-x']`, which i've added as labels on `e/e`) so that they're more discoverable.

/cc @ckerr @MarshallOfSound