### PR TITLE
feat: add concept of in-flight

### DIFF
--- a/src/backport/Probot.d.ts
+++ b/src/backport/Probot.d.ts
@@ -40,6 +40,7 @@ export interface PullRequest {
 
 export interface TropConfig {
   targetLabelPrefix?: string;
+  inFlightLabelPrefix?: string;
   mergedLabelPrefix?: string;
   authorizedUsers?: string[];
 }


### PR DESCRIPTION
Resolves https://github.com/electron/trop/issues/44.

This PR allows for trop PRs to now be marked `in-flight/4-0-x` when they are opened, and only marked `merged/4-0-x` when the backport PRs themselves have been merged.

/cc @MarshallOfSound 