### PR TITLE
fix: safer regex filtering for branch names

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -216,11 +216,8 @@ export const backportImpl = async (robot: Application,
 
       // Temp branch on the fork
       const sanitizedTitle = pr.title
-        .replace(/ /g, '-')
-        .replace(/\:/g, '-')
-        .replace(/\[/g, '-')
-        .replace(/\]/g, '-')
-        .replace(/\*/g, 'x').toLowerCase();
+        .replace(/\*/g, 'x').toLowerCase()
+        .replace(/[^a-zA-Z0-9_]+/g, '-');
       const tempBranch = `${targetBranch}-bp-${sanitizedTitle}-${Date.now()}`;
 
       log(`Checking out target: "target_repo/${targetBranch}" to temp: "${tempBranch}"`);

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -217,7 +217,7 @@ export const backportImpl = async (robot: Application,
       // Temp branch on the fork
       const sanitizedTitle = pr.title
         .replace(/\*/g, 'x').toLowerCase()
-        .replace(/[^a-zA-Z0-9_]+/g, '-');
+        .replace(/[^a-z0-9_]+/g, '-');
       const tempBranch = `${targetBranch}-bp-${sanitizedTitle}-${Date.now()}`;
 
       log(`Checking out target: "target_repo/${targetBranch}" to temp: "${tempBranch}"`);


### PR DESCRIPTION
Improve regex used to filter PR titles for generated trop branch names.

/cc @nornagon @MarshallOfSound