### PR TITLE
fix: correctly mark manual backports in-flight

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -407,7 +407,7 @@ export const backportToBranch = async (
   const labelPrefixes = await getLabelPrefixes(context);
 
   const labelToRemove = undefined;
-  const labelToAdd = labelPrefixes.merged + targetBranch;
+  const labelToAdd = labelPrefixes.inFlight + targetBranch;
   await backportImpl(
     robot, context, targetBranch, BackportPurpose.ExecuteBackport, labelToRemove, labelToAdd,
   );


### PR DESCRIPTION
Resolves https://github.com/electron/trop/issues/68.

Fixes an issue (see: [this PR](https://github.com/electron/electron/pull/15845)) whereby backport PRs triggered manually were calling `backportToBranch`, which was erroneously applying the `merged` label instead of the `in-flight` label.

/cc @ckerr 