### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Fall back to authors for all PR review
+* @MarshallOfSound @codebytere @ckerr


### PR DESCRIPTION
What it says on the tin.

Adds myself, @ckerr, and @MarshallOfSound as codeowners to simplify PR review request flow.