### PR TITLE
feat: error on unauthorized users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ PR is no longer targeting this branch for a backport',
     if (!config.authorizedUsers.includes(payload.comment.user.login)) {
       await context.github.issues.createComment(context.repo({
         number: payload.issue.number,
-        body: 'You are not authorized to run PR backports.',
+        body: `@${payload.comment.user.login} is not authorized to run PR backports.`,
       }));
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,10 @@ PR is no longer targeting this branch for a backport',
     if (!cmd.startsWith(TROP_COMMAND_PREFIX)) return;
 
     if (!config.authorizedUsers.includes(payload.comment.user.login)) {
-      robot.log.error('This user is not authorized to use trop');
+      await context.github.issues.createComment(context.repo({
+        number: payload.issue.number,
+        body: 'You are not authorized to run PR backports.',
+      }));
       return;
     }
 


### PR DESCRIPTION
Prior to this, trop would fail silently when unauthorized users attempted to trigger comment-based `trop` backports. This explicitly lets those users know that they are not allowed to perform backports so that we don't think trop is failing for a more systemic reason.

/cc @BinaryMuse @ckerr 