### PR TITLE
chore: add wg-releases codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Fall back to authors for all PR review
-* @MarshallOfSound @codebytere @ckerr
+* @electron/wg-releases


### PR DESCRIPTION
Update primary codeownership of trop to `@electron/wg-releases`, as it fall under one of their primary Associated Repositories.

cc @electron/wg-releases 