### PR TITLE
feat: support authenticated clones

### DIFF
--- a/src/backport/runner.ts
+++ b/src/backport/runner.ts
@@ -50,10 +50,17 @@ export const initRepo = async (options: InitRepoOptions) => {
   await fs.remove(dir);
   await fs.mkdirp(dir);
   const git = simpleGit(dir);
-  await git.clone(
-    `https://github.com/${slug}.git`,
-    '.',
-  );
+  if (process.env.GITHUB_FORK_USER_CLONE_LOGIN) {
+    await git.clone(
+      `https://${process.env.GITHUB_FORK_USER_CLONE_LOGIN}:${process.env.GITHUB_FORK_USER_TOKEN}@github.com/${slug}.git`,
+      '.',
+    );
+  } else {
+    await git.clone(
+      `https://github.com/${slug}.git`,
+      '.',
+    );
+  }
 
   // Clean up just in case
   await git.reset('hard');


### PR DESCRIPTION
Setting `GITHUB_FORK_USER_CLONE_LOGIN` to your fork user's username will use that user's creds to clone the source repo.

This allows trop to work on private github repositories