### PR TITLE
feat: add a GitHub check that prevents non-master non-backports

### DIFF
--- a/docs/manual-backports.md
+++ b/docs/manual-backports.md
@@ -7,9 +7,18 @@ in the PR yourself locally and pushing up a new branch.
 When you make a PR for a manual backport it must be in the following format.
 
 ```markdown
-Backport of #[Original PR Number]
+#### Description of Change
 
-{Normal PR Body}
+Backport of #[Original PR Number]
+See that PR for details.
+
+#### Checklist
+
+< Checklist Items>
+
+#### Release Notes
+
+Notes: <COPY ORIGINAL PR RELEASE NOTES HERE>
 ```
 
 If you raise a PR to a branch that isn't master without correctly tagging

--- a/docs/manual-backports.md
+++ b/docs/manual-backports.md
@@ -1,0 +1,17 @@
+# Manual Backports
+
+When `trop` fails to backport your PR (trust us it tried its best) you need
+to backport the PR manually.  You can do this by cherry-picking the commits
+in the PR yourself locally and pushing up a new branch.
+
+When you make a PR for a manual backport it must be in the following format.
+
+```markdown
+Backport of #[Original PR Number]
+
+{Normal PR Body}
+```
+
+If you raise a PR to a branch that isn't master without correctly tagging
+the original PR to master that this is backporting `trop` will create a
+"failed" check on that PR to prevent it being merged.

--- a/src/backport/Probot.d.ts
+++ b/src/backport/Probot.d.ts
@@ -22,6 +22,7 @@ export interface Repository {
 interface Ref {
   sha: string;
   repo: Repository;
+  ref: string;
 }
 
 export interface PullRequest {

--- a/src/backport/__tests__/fixtures/backport_pull_request.opened.json
+++ b/src/backport/__tests__/fixtures/backport_pull_request.opened.json
@@ -14,7 +14,13 @@
       "labels": [{
         "name": "todo",
         "color": "8cb728"
-      }]
+      }],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "master"
+      }
     },
     "label": {
       "name": "todo",

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -73,6 +73,9 @@ describe('trop', () => {
           ],
         })),
       },
+      checks: {
+        listForRef: jest.fn().mockReturnValue(Promise.resolve({ data: { check_runs: [] } })),
+      },
     };
 
     robot.auth = () => Promise.resolve(github);

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,9 +162,9 @@ Check out the trop documentation linked below for more information.';
 
         // The target PR is only "good" if it was merged to master
         if (oldPR.base.ref !== 'master') {
-          failureCause = 'the PR that it is backporting was not not targetting the master branch.';
+          failureCause = 'the PR that it is backporting was not targeting the master branch.';
         } else if (!oldPR.merged) {
-          failureCause = 'the PR that is is backporting has not been merged yet.';
+          failureCause = 'the PR that is backporting has not been merged yet.';
         }
       }
 
@@ -190,12 +190,12 @@ Check out the trop documentation linked below for more information.';
           details_url: 'https://github.com/electron/trop/blob/master/docs/manual-backports.md',
           output: {
             title: 'Invalid Backport',
-            summary: `This PR is targetting a branch that is not master but ${failureCause}`,
+            summary: `This PR is targeting a branch that is not master but ${failureCause}`,
           },
         }));
       }
     } else if (checkRun) {
-      // We are targetting master but for some reason have a check run???
+      // We are targeting master but for some reason have a check run???
       // Let's mark this check as cancelled
       await context.github.checks.update(context.repo({
         check_run_id: checkRun.id,
@@ -204,7 +204,7 @@ Check out the trop documentation linked below for more information.';
         completed_at: (new Date()).toISOString(),
         output: {
           title: 'Cancelled',
-          summary: 'This PR is targetting `master` and is not a backport',
+          summary: 'This PR is targeting `master` and is not a backport',
           annotations: [],
         },
       }));


### PR DESCRIPTION
When a PR is raised against a non-master branch Trop will try to figure out which PR it is "backporting".  If it can't determine it Trop will mark that PR as "failed" with a GitHub Check.

This ensures that no change can land in a release branch without having a corresponding commit / PR in master.  In cases where this must be overridden an Admin can bypass the merge check.

_Side Note_

This PR also fixes a few label creation / deletion bugs I found in the process of testing this PR.

See [this check](https://github.com/MarshallOfSound/electron/pull/78/checks?check_run_id=63908511) for an example of an invalid backport failed check.