### PR TITLE
fix: don't label PR title with target branch

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -265,7 +265,7 @@ export const backportImpl = async (robot: Application,
         const newPr = (await createFn(context.repo({
           head: `${fork.owner.login}:${tempBranch}`,
           base: targetBranch,
-          title: `${pr.title} (backport: ${targetBranch})`,
+          title: pr.title,
           body: createBackportComment(pr),
           maintainer_can_modify: true,
         }))).data;


### PR DESCRIPTION
Trop now adds `backport` and `$TARGET_BRANCH` labels to each PR so imo there's no longer a need to clutter the title with duplicate info.

cc @electron/wg-releases 