### PR TITLE
refactor: pull out constants, interfaces and enums

### DIFF
--- a/src/backport/__tests__/commands.spec.ts
+++ b/src/backport/__tests__/commands.spec.ts
@@ -1,4 +1,4 @@
-import * as commands from '../commands';
+import * as commands from '../../constants';
 
 describe('commands', () => {
   it('should all be unique', () => {

--- a/src/backport/commands.ts
+++ b/src/backport/commands.ts
@@ -1,3 +1,0 @@
-export const INIT_REPO = 'INIT_REPO';
-export const SET_UP_REMOTES = 'SET_UP_REMOTES';
-export const BACKPORT = 'BACKPORT';

--- a/src/backport/constants.ts
+++ b/src/backport/constants.ts
@@ -1,1 +1,0 @@
-export const CHECK_PREFIX = 'Backportable? - ';

--- a/src/backport/runner.ts
+++ b/src/backport/runner.ts
@@ -2,31 +2,14 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as simpleGit from 'simple-git/promise';
-import * as commands from './commands';
+import * as commands from '../constants';
 import * as config from 'config-yml';
 
-export interface InitRepoOptions {
-  owner: string;
-  repo: string;
-}
-
-export interface RemotesOptions {
-  dir: string;
-  remotes: {
-    name: string,
-    value: string,
-  }[];
-}
-
-export interface BackportOptions {
-  dir: string;
-  slug: string;
-  targetRemote: string;
-  targetBranch: string;
-  tempRemote: string;
-  tempBranch: string;
-  patches: string[];
-}
+import {
+  InitRepoOptions,
+  RemotesOptions,
+  BackportOptions,
+} from '../interfaces';
 
 export type RunnerOptions = {
   what: typeof commands.INIT_REPO;

--- a/src/backport/runner.ts
+++ b/src/backport/runner.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as simpleGit from 'simple-git/promise';
-import * as commands from '../constants';
+import { TropAction } from '../enums';
 import * as config from 'config-yml';
 
 import {
@@ -12,13 +12,13 @@ import {
 } from '../interfaces';
 
 export type RunnerOptions = {
-  what: typeof commands.INIT_REPO;
+  what: typeof TropAction.INIT_REPO;
   payload: InitRepoOptions;
 } | {
-  what: typeof commands.SET_UP_REMOTES;
+  what: typeof TropAction.SET_UP_REMOTES;
   payload: RemotesOptions;
 } | {
-  what: typeof commands.BACKPORT;
+  what: typeof TropAction.BACKPORT;
   payload: BackportOptions;
 };
 
@@ -101,11 +101,11 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
 
 export const runCommand = async (options: RunnerOptions): Promise<{ dir: string }> => {
   switch (options.what) {
-    case commands.INIT_REPO:
+    case TropAction.INIT_REPO:
       return await initRepo(options.payload);
-    case commands.SET_UP_REMOTES:
+    case TropAction.SET_UP_REMOTES:
       return await setUpRemotes(options.payload);
-    case commands.BACKPORT:
+    case TropAction.BACKPORT:
       return await backportCommitsToBranch(options.payload);
     default:
       throw new Error('wut u doin\' kiddo');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,1 @@
 export const CHECK_PREFIX = 'Backportable? - ';
-
-// trop comment labeling prefixes
-export const TARGET_LABEL_PREFIX = 'target/';
-export const MERGED_LABEL_PREFIX = 'merged/';
-export const IN_FLIGHT_LABEL_PREFIX = 'in-flight/';
-export const NEEDS_MANUAL_LABEL_PREFIX = 'needs-manual-bp/';
-
-// trop repo setup constants
-export const INIT_REPO = 'INIT_REPO';
-export const SET_UP_REMOTES = 'SET_UP_REMOTES';
-export const BACKPORT = 'BACKPORT';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,12 @@
+export const CHECK_PREFIX = 'Backportable? - ';
+
+// trop comment labeling prefixes
+export const TARGET_LABEL_PREFIX = 'target/';
+export const MERGED_LABEL_PREFIX = 'merged/';
+export const IN_FLIGHT_LABEL_PREFIX = 'in-flight/';
+export const NEEDS_MANUAL_LABEL_PREFIX = 'needs-manual-bp/';
+
+// trop repo setup constants
+export const INIT_REPO = 'INIT_REPO';
+export const SET_UP_REMOTES = 'SET_UP_REMOTES';
+export const BACKPORT = 'BACKPORT';

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,4 @@
+export enum PRChange {
+  OPEN,
+  CLOSE,
+}

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -2,3 +2,18 @@ export enum PRChange {
   OPEN,
   CLOSE,
 }
+
+// trop comment labeling prefixes
+export enum PRStatus {
+  TARGET = 'target/',
+  MERGED = 'merged/',
+  IN_FLIGHT = 'in-flight/',
+  NEEDS_MANUAL = 'needs-manual-bp/',
+}
+
+// trop repo setup constants
+export enum TropAction {
+  INIT_REPO = 'INIT_REPO',
+  SET_UP_REMOTES = 'SET_UP_REMOTES',
+  BACKPORT = 'BACKPORT',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,11 @@ import {
   BackportPurpose,
   labelMergedPR,
   updateManualBackport,
-  PRChange,
 } from './backport/utils';
 
 import { PullRequest, TropConfig } from './backport/Probot';
-import { CHECK_PREFIX } from './backport/constants';
+import { CHECK_PREFIX } from './constants';
+import { PRChange } from './enums';
 
 const probotHandler = async (robot: Application) => {
   if (!process.env.GITHUB_FORK_USER_TOKEN) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,25 @@
+// Used for git repo initialization and setup
+export interface InitRepoOptions {
+  owner: string;
+  repo: string;
+}
+
+// Used for adding and fetching repo remotes
+export interface RemotesOptions {
+  dir: string;
+  remotes: {
+    name: string,
+    value: string,
+  }[];
+}
+
+// Used for the actual backport application process
+export interface BackportOptions {
+  dir: string;
+  slug: string;
+  targetRemote: string;
+  targetBranch: string;
+  tempRemote: string;
+  tempBranch: string;
+  patches: string[];
+}


### PR DESCRIPTION
A first step in a trop refactor, which involves abstracting out trop's constants, enums, and interfaces in order to more clearly reason about their uses and locations.

cc @MarshallOfSound 