### PR TITLE
refactor: start moving tasks to operations dir

### DIFF
--- a/src/backport/__tests__/runner.spec.ts
+++ b/src/backport/__tests__/runner.spec.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as simpleGit from 'simple-git/promise';
 
-import { initRepo, setUpRemotes } from '../runner';
+import { initRepo, setupRemotes } from '../../operations/task-runner';
 
 let dirObject: { dir?: string } | null = null;
 
@@ -57,7 +57,7 @@ describe('runner', () => {
     });
 
     it('should set new remotes correctly', async () => {
-      await setUpRemotes({
+      await setupRemotes({
         dir,
         remotes: [{
           name: 'origin',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import {
   backportToBranch,
   backportToLabel,
   getLabelPrefixes,
-  labelToTargetBranch,
   backportImpl,
   BackportPurpose,
   labelMergedPR,
   updateManualBackport,
 } from './backport/utils';
 
+import { labelToTargetBranch } from './utils/label-utils';
 import { PullRequest, TropConfig } from './backport/Probot';
 import { CHECK_PREFIX } from './constants';
 import { PRChange } from './enums';

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -1,0 +1,33 @@
+import { Context } from 'probot';
+import { Label } from '../backport/Probot';
+
+export const addLabel = async (context: Context, prNumber: number, labelsToAdd: string[]) => {
+  return context.github.issues.addLabels(context.repo({
+    number: prNumber,
+    labels: labelsToAdd,
+  }));
+};
+
+export const removeLabel = async (context: Context, prNumber: number, labelToRemove: string) => {
+  // If the issue does not have the label, don't try remove it
+  if (!await labelExistsOnPR(context, labelToRemove)) return;
+
+  return context.github.issues.removeLabel(context.repo({
+    number: prNumber,
+    name: labelToRemove,
+  }));
+};
+
+export const labelToTargetBranch = (label: Label, prefix: string) => {
+  return label.name.replace(prefix, '');
+};
+
+export const labelExistsOnPR = async (context: Context, labelName: string) => {
+  const labels = await context.github.issues.listLabelsOnIssue(context.repo({
+    number: context.payload.pull_request.number,
+    per_page: 100,
+    page: 1,
+  }));
+
+  return labels.data.some(label => label.name === labelName);
+};


### PR DESCRIPTION
This PR begins to organize methods in a similar fashion to Sudowoodo, by organizing operations into a bespoke operations folder and a utils folder so that everything isn't crammed into `utils.ts`

cc @electron/wg-releases 