### PR TITLE
feat: remove need for fork user and fork token

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,9 +7,6 @@
     "APP_ID": {
       "required": true
     },
-    "GITHUB_FORK_USER_TOKEN": {
-      "required": true
-    },
     "PRIVATE_KEY": {
       "required": true
     }

--- a/docs/.example.env
+++ b/docs/.example.env
@@ -5,8 +5,6 @@ WEBHOOK_SECRET=development
 # Uncomment this to get verbose logging; use `info` to show less
 #LOG_LEVEL=trace
 
-GITHUB_FORK_USER_TOKEN=YOUR_USER_TOKEN
-
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 WEBHOOK_PROXY_URL=https://smee.io/<YOUR_UNIQUE_ID>
 `

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -25,15 +25,6 @@ To run your app in development, you will need to configure a GitHub App to deliv
 6. Update your GitHub App’s Webhook URL to your [smee.io](https://smee.io/) URL.
 7. Run `$ npm start` to start the server.
 
-### Configuring a Bot User
-
-To make things as safe as possible backports are done in a third party repo (a real github account).
-This bot will fork the base repo to this users account, backport the commits and then push to the
-fork.  For instance, we use [trop-bot](https://github.com/trop-bot) as our user to handle the forks.
-
-You must define your own bot user to use by declaring the `GITHUB_FORK_USER_TOKEN` variable in the
-`.env` file.  The value must be a personal access token with full "repo" access.
-
 ### Testing
 
 ```sh

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -20,7 +20,6 @@ describe('trop', () => {
   let github: any;
 
   beforeEach(async () => {
-    process.env.GITHUB_FORK_USER_TOKEN = 'fake';
     robot = new Application();
     await trop(robot);
 

--- a/src/backport/__tests__/operations.spec.ts
+++ b/src/backport/__tests__/operations.spec.ts
@@ -26,8 +26,8 @@ describe('runner', () => {
   describe('initRepo()', () => {
     it('should clone a github repository', async () => {
       const dir = saveDir(await initRepo({
-        owner: 'electron',
-        repo: 'trop',
+        slug: 'electron/trop',
+        accessToken: '',
       }));
       expect(await fs.pathExists(dir)).toBe(true);
       expect(await fs.pathExists(path.resolve(dir, '.git'))).toBe(true);
@@ -35,8 +35,8 @@ describe('runner', () => {
 
     it('should fail if the github repository does not exist', async () => {
       await expect(initRepo({
-        owner: 'electron',
-        repo: 'this-is-not-trop',
+        slug: 'electron/this-is-not-trop',
+        accessToken: '',
       })).rejects.toBeTruthy();
     });
   });

--- a/src/backport/token.ts
+++ b/src/backport/token.ts
@@ -1,0 +1,9 @@
+import { Context, Application } from 'probot';
+
+export const getRepoToken = async (robot: Application, context: Context): Promise<string> => {
+  const hub = await robot.auth();
+  const response = await hub.apps.createInstallationToken({
+    installation_id: context.payload.installation.id,
+  });
+  return response.data.token;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,9 @@ import { PullRequest, TropConfig } from './backport/Probot';
 import { CHECK_PREFIX } from './constants';
 import { PRChange } from './enums';
 import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
+import { getRepoToken } from './backport/token';
 
 const probotHandler = async (robot: Application) => {
-  if (!process.env.GITHUB_FORK_USER_TOKEN) {
-    robot.log.error('You must set GITHUB_FORK_USER_TOKEN');
-    process.exit(1);
-  }
-
   const labelMergedPRs = async (context: Context, pr: PullRequest) => {
     for (const label of pr.labels) {
       const targetBranch = label.name.match(/(\d)-(\d)-x/);
@@ -107,7 +103,7 @@ PR is no longer targeting this branch for a backport',
     const pr = context.payload.pull_request;
     let backportNumber: null | number = null;
 
-    if (!pr.user.login.endsWith('[bot]') && pr.user.login !== process.env.GITHUB_FORK_USER_CLONE_LOGIN) {
+    if (!pr.user.login.endsWith('[bot]')) {
       // check if this PR is a manual backport of another PR
       const backportPattern = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/im;
       const match: Array<string> | null = pr.body.match(backportPattern);

--- a/src/operations/backport-commits.ts
+++ b/src/operations/backport-commits.ts
@@ -6,9 +6,9 @@ export interface BackportOptions {
   slug: string;
   targetRemote: string;
   targetBranch: string;
-  tempRemote: string;
   tempBranch: string;
   patches: string[];
+  shouldPush: boolean;
 }
 
 /*
@@ -19,7 +19,6 @@ export interface BackportOptions {
 * 2) targetBranch - the target branch
 * 3) patches - a list of patches to apply to the target branch
 * 3) tempBranch - the temporary branch to PR against the target branch
-* 4) tempRemote - the temporary remote for use in backporting
 * @returns {Object} - an object containing the repo initialization directory
 */
 export const backportCommitsToBranch = async (options: BackportOptions) => {
@@ -38,8 +37,10 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
   }
 
   // Push
-  await git.push(options.tempRemote, options.tempBranch, {
-    '--set-upstream': true,
-  });
+  if (options.shouldPush) {
+    await git.push(options.targetRemote, options.tempBranch, {
+      '--set-upstream': true,
+    });
+  }
   return { dir: options.dir };
 };

--- a/src/operations/init-repo.ts
+++ b/src/operations/init-repo.ts
@@ -7,8 +7,8 @@ import * as simpleGit from 'simple-git/promise';
 const baseDir = path.resolve(os.tmpdir(), 'trop-working');
 
 export interface InitRepoOptions {
-  owner: string;
-  repo: string;
+  slug: string;
+  accessToken: string;
 }
 
 /*
@@ -17,32 +17,22 @@ export interface InitRepoOptions {
 * @param {InitRepoOptions} repo and payload for repo initialization
 * @returns {Object} - an object containing the repo initialization directory
 */
-export const initRepo = async (options: InitRepoOptions) => {
-  const slug = `${options.owner}/${options.repo}`;
+export const initRepo = async ({ slug, accessToken }: InitRepoOptions) => {
   await fs.mkdirp(path.resolve(baseDir, slug));
-  const prefix = path.resolve(baseDir, slug, 'tmp-');
+  const prefix = path.resolve(baseDir, slug, 'job-');
   const dir = await fs.mkdtemp(prefix);
+
+  // Be super-duper sure that this directory is empty
   await fs.mkdirp(dir);
   await fs.remove(dir);
   await fs.mkdirp(dir);
+
   const git = simpleGit(dir);
 
-  const forkLogin = process.env.GITHUB_FORK_USER_CLONE_LOGIN;
-  const forkToken = process.env.GITHUB_FORK_USER_TOKEN;
-
-  // Adds support for the target_repo being private as
-  // long as the fork user has read access
-  if (forkLogin) {
-    await git.clone(
-      `https://${forkLogin}:${forkToken}@github.com/${slug}.git`,
-      '.',
-    );
-  } else {
-    await git.clone(
-      `https://github.com/${slug}.git`,
-      '.',
-    );
-  }
+  await git.clone(
+    `https://x-access-token:${accessToken}@github.com/${slug}.git`,
+    '.',
+  );
 
   // Clean up just in case
   await git.reset('hard');


### PR DESCRIPTION
This removes the need for the fork user hack when making backports.  We now push all backports to `trop/*` branches on the _actual_ repository.  This means that PRs, commits, branches, everything are pushed and owned by the bot.

This is a required chunk of work to move towards actionification and makes the Private Repository workflow _wayyyyy_ better.  It would allow us to put `trop` in its current state on the GitHub Marketplace as others could just install it and it would work on any repository (private or public)