### PR TITLE
feat: allow fasttrack backports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ PR is no longer targeting this branch for a backport',
 
         const FASTTRACK_PREFIXES = ['build:', 'ci:'];
         const FASTTRACK_USERS = ['electron-bot'];
-        const FASTTRACK_LABELS: string[] = [];
+        const FASTTRACK_LABELS: string[] = ['fast-track 🚅'];
         let failureCause = '';
 
         if (!oldPRNumber) {


### PR DESCRIPTION
Allows us to label backport PRs as fasttrack to bypass the Valid Backport check