### PR TITLE
fix: trop[bot] needs to be a fast-track user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ PR is no longer targeting this branch for a backport',
         }
 
         const FASTTRACK_PREFIXES = ['build:', 'ci:'];
-        const FASTTRACK_USERS = ['electron-bot'];
+        const FASTTRACK_USERS = ['electron-bot', 'trop[bot]'];
         const FASTTRACK_LABELS: string[] = ['fast-track 🚅'];
         let failureCause = '';
 


### PR DESCRIPTION
`trop[bot]` opens backport PRs and thus needs to be a fast-track user. Caused the following [fail](https://github.com/electron/electron/pull/17909).

cc @MarshallOfSound 