### PR TITLE
feat: enable trop to delete its own branches when they're merged

### DIFF
--- a/src/backport/__tests__/fixtures/backport_pull_request.closed.bot.json
+++ b/src/backport/__tests__/fixtures/backport_pull_request.closed.bot.json
@@ -7,7 +7,10 @@
       "state": "closed",
       "title": "mirror (backport: 4-0-x)",
       "user": {
-        "login": "tropvel[bot]"
+        "login": "trop[bot]"
+      },
+      "base": {
+        "ref": "123456789iuytdxcvbnjhfdriuyfedfgy54escghjnbg"
       },
       "body": "Backport of #14\n\nSee that PR for details.\n\n\r\nNotes: <!-- One-line Change Summary Here-->",
       "created_at": "2018-11-01T17:29:51Z",

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -30,6 +30,9 @@ describe('trop', () => {
         })),
         getBranch: jest.fn().mockReturnValue(Promise.resolve()),
       },
+      gitdata: {
+        deleteRef: jest.fn().mockReturnValue(Promise.resolve()),
+      },
       pullRequests: {
         get: jest.fn().mockReturnValue(Promise.resolve({
           data: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,4 @@
 export const CHECK_PREFIX = 'Backportable? - ';
+
+export const TROP_BOT = 'trop[bot]';
+export const ELECTRON_BOT = 'electron-bot';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,9 @@ import {
 
 import { labelToTargetBranch } from './utils/label-utils';
 import { PullRequest, TropConfig } from './backport/Probot';
-import { CHECK_PREFIX } from './constants';
+import { CHECK_PREFIX, TROP_BOT, ELECTRON_BOT } from './constants';
 import { PRChange } from './enums';
 import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
-import { getRepoToken } from './backport/token';
 
 const probotHandler = async (robot: Application) => {
   const labelMergedPRs = async (context: Context, pr: PullRequest) => {
@@ -103,7 +102,7 @@ PR is no longer targeting this branch for a backport',
     const pr = context.payload.pull_request;
     let backportNumber: null | number = null;
 
-    if (pr.user.login !== 'trop[bot]') {
+    if (pr.user.login !== TROP_BOT) {
       // check if this PR is a manual backport of another PR
       const backportPattern = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/im;
       const match: Array<string> | null = pr.body.match(backportPattern);
@@ -151,7 +150,7 @@ PR is no longer targeting this branch for a backport',
         }
 
         const FASTTRACK_PREFIXES = ['build:', 'ci:'];
-        const FASTTRACK_USERS = ['electron-bot', 'trop[bot]'];
+        const FASTTRACK_USERS = [ELECTRON_BOT, TROP_BOT];
         const FASTTRACK_LABELS: string[] = ['fast-track 🚅'];
         let failureCause = '';
 
@@ -237,7 +236,7 @@ PR is no longer targeting this branch for a backport',
     const pr = context.payload.pull_request;
     if (pr.merged) {
       // check that the closed PR is trop's own and close
-      if (pr.user.login === 'trop[bot]') {
+      if (pr.user.login === TROP_BOT) {
         context.github.gitdata.deleteRef(context.repo({
           ref: pr.base.ref,
         }));
@@ -248,7 +247,7 @@ PR is no longer targeting this branch for a backport',
         await updateManualBackport(context, PRChange.OPEN, oldPRNumber);
       }
 
-      if (pr.user.login === 'trop[bot]') {
+      if (pr.user.login === TROP_BOT) {
         await labelMergedPRs(context, pr as any);
       } else {
         backportAllLabels(context, pr as any);


### PR DESCRIPTION
Since trop no longer opens PRs from a fork, there are now dangling branches left when its PRs are merged. This PR thus enables trop to delete its own branches when they're merged.

cc @MarshallOfSound 