### PR TITLE
chore: remove unused config file for label prefixes

### DIFF
--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -1,5 +1,4 @@
 import { Context } from 'probot';
-import { PRStatus } from '../enums';
 import { Label } from '../backport/Probot';
 
 export const addLabel = async (context: Context, prNumber: number, labelsToAdd: string[]) => {

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -1,4 +1,5 @@
 import { Context } from 'probot';
+import { PRStatus } from '../enums';
 import { Label } from '../backport/Probot';
 
 export const addLabel = async (context: Context, prNumber: number, labelsToAdd: string[]) => {


### PR DESCRIPTION
We don't use Probot's configuration file for anything to do with label prefixing, so we can simplify this code a bit by removing the unnecessary helper method.

cc @MarshallOfSound 