### PR TITLE
fix: duplicate issue comments for status changes

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -325,7 +325,7 @@ export const updateManualBackport = async (
 
   if (type === PRChange.OPEN) {
     labelToRemove = PRStatus.NEEDS_MANUAL + pr.base.ref;
-    if (!await labelUtils.labelExistsOnPR(context, labelToRemove)) {
+    if (!await labelUtils.labelExistsOnPR(context, pr.number, labelToRemove)) {
       labelToRemove = PRStatus.TARGET + pr.base.ref;
     }
     labelToAdd = PRStatus.IN_FLIGHT + pr.base.ref;

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,7 @@ PR is no longer targeting this branch for a backport',
       const oldPRNumber = maybeGetManualBackportNumber(context);
       if (typeof oldPRNumber === 'number') {
         await updateManualBackport(context, PRChange.OPEN, oldPRNumber);
+        await labelMergedPRs(context, pr as any);
       }
 
       if (pr.user.login === TROP_BOT) {

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -10,7 +10,7 @@ export const addLabel = async (context: Context, prNumber: number, labelsToAdd: 
 
 export const removeLabel = async (context: Context, prNumber: number, labelToRemove: string) => {
   // If the issue does not have the label, don't try remove it
-  if (!await labelExistsOnPR(context, labelToRemove)) return;
+  if (!await labelExistsOnPR(context, prNumber, labelToRemove)) return;
 
   return context.github.issues.removeLabel(context.repo({
     number: prNumber,
@@ -22,9 +22,9 @@ export const labelToTargetBranch = (label: Label, prefix: string) => {
   return label.name.replace(prefix, '');
 };
 
-export const labelExistsOnPR = async (context: Context, labelName: string) => {
+export const labelExistsOnPR = async (context: Context, prNumber: number, labelName: string) => {
   const labels = await context.github.issues.listLabelsOnIssue(context.repo({
-    number: context.payload.pull_request.number,
+    number: prNumber,
     per_page: 100,
     page: 1,
   }));


### PR DESCRIPTION
Fixes https://github.com/electron/trop/issues/101.

A check was added to ensure that the PR instigating had the label in question for removal, but when backport PRs are merged the label in question needs to exist on the _original_ PR and so this check would incorrectly fail. Thus we also should pass the PR number to check against.

We should also be updating labels on manual backport merges, so I've also added that here.

cc @MarshallOfSound 