### PR TITLE
fix: double commenting on manual backport open

### DIFF
--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -325,7 +325,7 @@ export const updateManualBackport = async (
 
   if (type === PRChange.OPEN) {
     labelToRemove = PRStatus.NEEDS_MANUAL + pr.base.ref;
-    if (!await labelUtils.labelExistsOnPR(context, pr.number, labelToRemove)) {
+    if (!await labelUtils.labelExistsOnPR(context, oldPRNumber, labelToRemove)) {
       labelToRemove = PRStatus.TARGET + pr.base.ref;
     }
     labelToAdd = PRStatus.IN_FLIGHT + pr.base.ref;

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,9 @@ PR is no longer targeting this branch for a backport',
     ],
     async (context: Context) => {
       const oldPRNumber = maybeGetManualBackportNumber(context);
-      if (oldPRNumber) {
+
+      // only check for manual backports when a new PR is opened or if the PR body is edited
+      if (oldPRNumber && ['opened', 'edited'].includes(context.payload.action)) {
         await updateManualBackport(context, PRChange.OPEN, oldPRNumber);
       }
 
@@ -241,7 +243,7 @@ PR is no longer targeting this branch for a backport',
       }
 
       const oldPRNumber = maybeGetManualBackportNumber(context);
-      if (typeof oldPRNumber === 'number') {
+      if (oldPRNumber) {
         await updateManualBackport(context, PRChange.OPEN, oldPRNumber);
         await labelMergedPRs(context, pr as any);
       }


### PR DESCRIPTION
Fixes https://github.com/electron/trop/issues/100.

Correctly pass the old backport number to check for the `needs-manual` label as well as more tightly scope when `updateManualBackport` is called to PRs being opened and closed.

cc @MarshallOfSound 