### PR TITLE
feat: allow consumers to set bot names in env

### DIFF
--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -18,6 +18,7 @@ const issueCommentBackportToMultipleCreatedEvent = require('./fixtures/issue_com
 describe('trop', () => {
   let robot: any;
   let github: any;
+  process.env = { BOT_USER_NAME: 'electron-bot' };
 
   beforeEach(async () => {
     robot = new Application();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,1 @@
 export const CHECK_PREFIX = 'Backportable? - ';
-
-export const TROP_BOT = 'trop[bot]';
-export const ELECTRON_BOT = 'electron-bot';

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Checks that a given environment variable exists, and returns
+ * its value if it does. Throws an error on failure.
+ *
+ * @param {string} envVar
+ * @returns string - the value of the env var being checked
+ */
+export function getEnvVar(envVar: string): string {
+  const value = process.env[envVar];
+  if (!value) throw new Error(`Missing environment variable ${envVar}`);
+  return value;
+}


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/105.

Extracts bot names (in our case `trop[bot]` and `electron-bot`) to environment variables to increase trop's extensibility. Check env vars when they are used to ensure they've been appropriately set, or throw an error to let users know they need to set them.

cc @electron/wg-releases 