### PR TITLE
fix: invalid backports when links are used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,9 @@ PR is no longer targeting this branch for a backport',
       // check if this PR is a manual backport of another PR
       const backportPattern = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/im;
       const match: Array<string> | null = pr.body.match(backportPattern);
-      if (match && match[1]) {
-        backportNumber = parseInt(match[1], 10);
+      if (match) {
+        // This might be the first or second capture group depending on if it's a link or not
+        backportNumber = !!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10);
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/electron/trop/issues/107.

We account for both links and PR numbers when searching a PR body to look for valid backports, but did not take into account that this changes which capture group is populated with the valid number. 

This PR adds a truthy check to the first capture group (a PR number), and if it's `undefined` uses the second capture group's value, which must then be correct because the user pasted a link.

cc @MarshallOfSound 
