### PR TITLE
refactor: move backport to branch/label to ops

### DIFF
--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -2,6 +2,7 @@ jest.mock('request');
 const { Application } = require('probot');
 
 import * as utils from '../utils';
+import * as backportOperations from '../../operations/backport-to-location';
 import { ProbotHandler } from '../../index';
 
 const trop: ProbotHandler = require('../../index');
@@ -95,51 +96,51 @@ describe('trop', () => {
 
   describe('issue_comment.created event', () => {
     it('manually triggers the backport on comment', async () => {
-      Object.defineProperty(utils, 'backportToLabel', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToLabel', { value: jest.fn() });
       await robot.receive(issueCommentBackportCreatedEvent);
 
       expect(github.pullRequests.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
-      expect(utils.backportToLabel).toHaveBeenCalled();
+      expect(backportOperations.backportToLabel).toHaveBeenCalled();
     });
 
     it('does not trigger the backport on comment if the PR is not merged', async () => {
-      Object.defineProperty(utils, 'backportToLabel', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToLabel', { value: jest.fn() });
       github.pullRequests.get = jest.fn().mockReturnValue(Promise.resolve({ data: { merged: false } }));
 
       await robot.receive(issueCommentBackportCreatedEvent);
 
       expect(github.pullRequests.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
-      expect(utils.backportToLabel).not.toHaveBeenCalled();
+      expect(backportOperations.backportToLabel).not.toHaveBeenCalled();
     });
 
     it('triggers the backport on comment to a targeted branch', async () => {
-      Object.defineProperty(utils, 'backportToBranch', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToBranch', { value: jest.fn() });
       await robot.receive(issueCommentBackportToCreatedEvent);
 
       expect(github.pullRequests.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
-      expect(utils.backportToBranch).toHaveBeenCalled();
+      expect(backportOperations.backportToBranch).toHaveBeenCalled();
     });
 
     it('allows for multiple PRs to be triggered in the same comment', async () => {
-      Object.defineProperty(utils, 'backportToBranch', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToBranch', { value: jest.fn() });
       await robot.receive(issueCommentBackportToMultipleCreatedEvent);
 
       expect(github.pullRequests.get).toHaveBeenCalledTimes(3);
       expect(github.issues.createComment).toHaveBeenCalledTimes(2);
-      expect(utils.backportToBranch).toHaveBeenCalledTimes(2);
+      expect(backportOperations.backportToBranch).toHaveBeenCalledTimes(2);
     });
 
     it('does not trigger the backport on comment to a targeted branch if the branch does not exist', async () => {
-      Object.defineProperty(utils, 'backportToBranch', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToBranch', { value: jest.fn() });
       github.repos.getBranch = jest.fn().mockReturnValue(Promise.reject(new Error('404')));
       await robot.receive(issueCommentBackportToCreatedEvent);
 
       expect(github.pullRequests.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
-      expect(utils.backportToBranch).toHaveBeenCalledTimes(0);
+      expect(backportOperations.backportToBranch).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -154,10 +155,10 @@ describe('trop', () => {
 
   describe('pull_request.closed event', () => {
     it('begins the backporting process if the PR was merged', async () => {
-      Object.defineProperty(utils, 'backportToLabel', { value: jest.fn() });
+      Object.defineProperty(backportOperations, 'backportToLabel', { value: jest.fn() });
       await robot.receive(prClosedEvent);
 
-      expect(utils.backportToLabel).toHaveBeenCalled();
+      expect(backportOperations.backportToLabel).toHaveBeenCalled();
     });
 
     it('adds a label when a backport PR has been merged', async () => {

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -8,7 +8,7 @@ import * as simpleGit from 'simple-git/promise';
 import { Label, PullRequest } from './Probot';
 import queue from './Queue';
 import { CHECK_PREFIX } from '../constants';
-import { PRChange, PRStatus } from '../enums';
+import { PRChange, PRStatus, BackportPurpose } from '../enums';
 
 import * as labelUtils from '../utils/label-utils';
 import { initRepo } from '../operations/init-repo';
@@ -50,11 +50,6 @@ const createBackportComment = (pr: PullRequest) => {
 
   return body;
 };
-
-export enum BackportPurpose {
-  ExecuteBackport,
-  Check,
-}
 
 export const backportImpl = async (robot: Application,
                                    context: Context,
@@ -357,39 +352,4 @@ please check out #${pr.number}`;
 
   await labelUtils.removeLabel(context, oldPRNumber, labelToRemove);
   await labelUtils.addLabel(context, oldPRNumber, [labelToAdd]);
-};
-
-export const backportToLabel = async (
-  robot: Application,
-  context: Context,
-  label: Label,
-) => {
-  if (!label.name.startsWith(PRStatus.TARGET)) {
-    robot.log(`Label '${label.name}' does not begin with '${PRStatus.TARGET}'`);
-    return;
-  }
-
-  const targetBranch = labelUtils.labelToTargetBranch(label, PRStatus.TARGET);
-  if (!targetBranch) {
-    robot.log('Nothing to do');
-    return;
-  }
-
-  const labelToRemove = label.name;
-  const labelToAdd = label.name.replace(PRStatus.TARGET, PRStatus.IN_FLIGHT);
-  await backportImpl(
-    robot, context, targetBranch, BackportPurpose.ExecuteBackport, labelToRemove, labelToAdd,
-  );
-};
-
-export const backportToBranch = async (
-  robot: Application,
-  context: Context,
-  targetBranch: string,
-) => {
-  const labelToRemove = undefined;
-  const labelToAdd = PRStatus.IN_FLIGHT + targetBranch;
-  await backportImpl(
-    robot, context, targetBranch, BackportPurpose.ExecuteBackport, labelToRemove, labelToAdd,
-  );
 };

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -3,6 +3,11 @@ export enum PRChange {
   CLOSE,
 }
 
+export enum BackportPurpose {
+  ExecuteBackport,
+  Check,
+}
+
 // trop comment labeling prefixes
 export enum PRStatus {
   TARGET = 'target/',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 import { Application, Context } from 'probot';
 
 import {
-  backportToBranch,
-  backportToLabel,
   backportImpl,
-  BackportPurpose,
   labelMergedPR,
   updateManualBackport,
 } from './backport/utils';
@@ -12,9 +9,10 @@ import {
 import { labelToTargetBranch } from './utils/label-utils';
 import { PullRequest, TropConfig } from './backport/Probot';
 import { CHECK_PREFIX } from './constants';
-import { PRChange, PRStatus } from './enums';
-import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
 import { getEnvVar } from './utils/env-utils';
+import { PRChange, PRStatus, BackportPurpose } from './enums';
+import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
+import { backportToLabel, backportToBranch } from './operations/backport-to-location';
 
 const probotHandler = async (robot: Application) => {
   const labelMergedPRs = async (context: Context, pr: PullRequest) => {

--- a/src/operations/backport-to-location.ts
+++ b/src/operations/backport-to-location.ts
@@ -1,0 +1,60 @@
+import { Application, Context } from 'probot';
+import { Label } from '../backport/Probot';
+import { PRStatus, BackportPurpose } from '../enums';
+import * as labelUtils from '../utils/label-utils';
+import { backportImpl } from '../backport/utils';
+
+/*
+* Performs a backport to a specified label.
+*
+* @param {Label} the label representing the target branch for backporting
+*/
+export const backportToLabel = async (
+  robot: Application,
+  context: Context,
+  label: Label,
+) => {
+  if (!label.name.startsWith(PRStatus.TARGET)) {
+    robot.log(`Label '${label.name}' does not begin with '${PRStatus.TARGET}'`);
+    return;
+  }
+
+  const targetBranch = labelUtils.labelToTargetBranch(label, PRStatus.TARGET);
+  if (!targetBranch) {
+    robot.log('Nothing to do');
+    return;
+  }
+
+  const labelToRemove = label.name;
+  const labelToAdd = label.name.replace(PRStatus.TARGET, PRStatus.IN_FLIGHT);
+  await backportImpl(
+    robot,
+    context,
+    targetBranch,
+    BackportPurpose.ExecuteBackport,
+    labelToRemove,
+    labelToAdd,
+  );
+};
+
+/*
+* Performs a backport to a specified target branch
+*
+* @param {string} the branch to which the backport will be performed.
+*/
+export const backportToBranch = async (
+  robot: Application,
+  context: Context,
+  targetBranch: string,
+) => {
+  const labelToRemove = undefined;
+  const labelToAdd = PRStatus.IN_FLIGHT + targetBranch;
+  await backportImpl(
+    robot,
+    context,
+    targetBranch,
+    BackportPurpose.ExecuteBackport,
+    labelToRemove,
+    labelToAdd,
+  );
+};


### PR DESCRIPTION
Continues to split out the utils file into operations. This PR specifically moves the backport to branch and backport to label actions into their own operations file.

cc @MarshallOfSound 