### PR TITLE
test: clean up spec utility fn mocks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   },
+  clearMocks: true,
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: [
     'ts',


### PR DESCRIPTION
This PR cleans up our use of Jest function mocks so that we don't need to define the same object property in each test.

cc @MarshallOfSound @ckerr 