### PR TITLE
chore: update probot to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   },
   "dependencies": {
     "@octokit/rest": "^16.15.0",
+    "@types/ioredis": "^4.0.12",
+    "@types/lru-cache": "^5.1.0",
     "config-yml": "^0.10.2",
     "fs-extra": "^7.0.0",
     "node-fetch": "^2.1.1",
-    "probot": "~7.0.0",
+    "probot": "^9.2.5",
     "queue": "^4.5.0",
     "simple-git": "1.105.0",
     "what-the-diff": "^0.4.0"

--- a/src/backport/__tests__/fixtures/backport_pull_request.closed.bot.json
+++ b/src/backport/__tests__/fixtures/backport_pull_request.closed.bot.json
@@ -1,5 +1,5 @@
 {
-  "event": "pull_request",
+  "name": "pull_request",
   "payload": {
     "action": "closed",
     "number": 15,

--- a/src/backport/__tests__/fixtures/backport_pull_request.closed.json
+++ b/src/backport/__tests__/fixtures/backport_pull_request.closed.json
@@ -1,5 +1,5 @@
 {
-  "event": "pull_request",
+  "name": "pull_request",
   "payload": {
     "action": "closed",
     "number": 15,

--- a/src/backport/__tests__/fixtures/backport_pull_request.opened.json
+++ b/src/backport/__tests__/fixtures/backport_pull_request.opened.json
@@ -1,5 +1,5 @@
 {
-  "event": "pull_request",
+  "name": "pull_request",
   "payload": {
     "action": "opened",
     "number": 7,

--- a/src/backport/__tests__/fixtures/issue_comment_backport.created.json
+++ b/src/backport/__tests__/fixtures/issue_comment_backport.created.json
@@ -1,5 +1,5 @@
 {
-  "event": "issue_comment",
+  "name": "issue_comment",
   "payload": {
     "action": "created",
     "issue": {

--- a/src/backport/__tests__/fixtures/issue_comment_backport_to.created.json
+++ b/src/backport/__tests__/fixtures/issue_comment_backport_to.created.json
@@ -1,5 +1,5 @@
 {
-  "event": "issue_comment",
+  "name": "issue_comment",
   "payload": {
     "action": "created",
     "issue": {

--- a/src/backport/__tests__/fixtures/issue_comment_backport_to_multiple.created.json
+++ b/src/backport/__tests__/fixtures/issue_comment_backport_to_multiple.created.json
@@ -1,5 +1,5 @@
 {
-  "event": "issue_comment",
+  "name": "issue_comment",
   "payload": {
     "action": "created",
     "issue": {

--- a/src/backport/__tests__/fixtures/pull_request.closed.json
+++ b/src/backport/__tests__/fixtures/pull_request.closed.json
@@ -1,5 +1,5 @@
 {
-  "event": "pull_request",
+  "name": "pull_request",
   "payload": {
     "action": "closed",
     "number": 7,
@@ -25,9 +25,6 @@
       "owner": {
         "login": "codebytere"
       }
-    },
-    "installation": {
-      "id": 103619
     }
   }
 }

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -39,10 +39,10 @@ describe('trop', () => {
         })),
         getBranch: jest.fn().mockReturnValue(Promise.resolve()),
       },
-      gitdata: {
+      git: {
         deleteRef: jest.fn().mockReturnValue(Promise.resolve()),
       },
-      pullRequests: {
+      pulls: {
         get: jest.fn().mockReturnValue(Promise.resolve({
           data: {
             merged: true,
@@ -94,7 +94,6 @@ describe('trop', () => {
 
   describe('config', () => {
     it('fetches config', async () => {
-      Object.defineProperty(utils, 'backportToLabel', { value: jest.fn() });
       await robot.receive(issueCommentBackportCreatedEvent);
 
       expect(github.repos.getContent).toHaveBeenCalled();
@@ -105,7 +104,7 @@ describe('trop', () => {
     it('manually triggers the backport on comment', async () => {
       await robot.receive(issueCommentBackportCreatedEvent);
 
-      expect(github.pullRequests.get).toHaveBeenCalled();
+      expect(github.pulls.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
       expect(backportToLabel).toHaveBeenCalled();
     });
@@ -115,7 +114,7 @@ describe('trop', () => {
 
       await robot.receive(issueCommentBackportCreatedEvent);
 
-      expect(github.pullRequests.get).toHaveBeenCalled();
+      expect(github.pulls.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
       expect(backportToLabel).not.toHaveBeenCalled();
     });
@@ -123,7 +122,7 @@ describe('trop', () => {
     it('triggers the backport on comment to a targeted branch', async () => {
       await robot.receive(issueCommentBackportToCreatedEvent);
 
-      expect(github.pullRequests.get).toHaveBeenCalled();
+      expect(github.pulls.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
       expect(backportToBranch).toHaveBeenCalled();
     });
@@ -131,7 +130,7 @@ describe('trop', () => {
     it('allows for multiple PRs to be triggered in the same comment', async () => {
       await robot.receive(issueCommentBackportToMultipleCreatedEvent);
 
-      expect(github.pullRequests.get).toHaveBeenCalledTimes(3);
+      expect(github.pulls.get).toHaveBeenCalledTimes(3);
       expect(github.issues.createComment).toHaveBeenCalledTimes(2);
       expect(backportToBranch).toHaveBeenCalledTimes(2);
     });
@@ -140,7 +139,7 @@ describe('trop', () => {
       github.repos.getBranch = jest.fn().mockReturnValue(Promise.reject(new Error('404')));
       await robot.receive(issueCommentBackportToCreatedEvent);
 
-      expect(github.pullRequests.get).toHaveBeenCalled();
+      expect(github.pulls.get).toHaveBeenCalled();
       expect(github.issues.createComment).toHaveBeenCalled();
       expect(backportToBranch).toHaveBeenCalledTimes(0);
     });

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 jest.mock('request');
-const { Application } = require('probot');
+import { Application } from 'probot';
 
 import * as utils from '../utils';
 import { backportToBranch, backportToLabel } from '../../operations/backport-to-location';
@@ -24,17 +24,17 @@ jest.mock('../../operations/backport-to-location', () => ({
 }));
 
 describe('trop', () => {
-  let robot: any;
+  let robot: Application;
   let github: any;
   process.env = { BOT_USER_NAME: 'electron-bot' };
 
-  beforeEach(async () => {
+  beforeEach(() => {
     robot = new Application();
-    await trop(robot);
+    robot.load(trop);
 
     github = {
       repos: {
-        getContent: jest.fn().mockReturnValue(Promise.resolve({
+        getContents: jest.fn().mockReturnValue(Promise.resolve({
           data: { content: Buffer.from('watchedProject:\n  name: Radar\nauthorizedUsers:\n  - codebytere').toString('base64') },
         })),
         getBranch: jest.fn().mockReturnValue(Promise.resolve()),
@@ -96,7 +96,7 @@ describe('trop', () => {
     it('fetches config', async () => {
       await robot.receive(issueCommentBackportCreatedEvent);
 
-      expect(github.repos.getContent).toHaveBeenCalled();
+      expect(github.repos.getContents).toHaveBeenCalled();
     });
   });
 
@@ -110,7 +110,7 @@ describe('trop', () => {
     });
 
     it('does not trigger the backport on comment if the PR is not merged', async () => {
-      github.pullRequests.get = jest.fn().mockReturnValue(Promise.resolve({ data: { merged: false } }));
+      github.pulls.get = jest.fn().mockReturnValue(Promise.resolve({ data: { merged: false } }));
 
       await robot.receive(issueCommentBackportCreatedEvent);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ PR is no longer targeting this branch for a backport',
   Check out the trop documentation linked below for more information.';
           }
         } else {
-          const oldPR = (await context.github.pullRequests.get(context.repo({
+          const oldPR = (await context.github.pulls.get(context.repo({
             number: oldPRNumber,
           }))).data;
 
@@ -231,12 +231,12 @@ PR is no longer targeting this branch for a backport',
   robot.on('pull_request.unlabeled', maybeRunCheck);
 
   // backport pull requests to labeled targets when PR is merged
-  robot.on('pull_request.closed', async (context) => {
+  robot.on('pull_request.closed', async (context: Context) => {
     const pr = context.payload.pull_request;
     if (pr.merged) {
       // check that the closed PR is trop's own and close
       if (pr.user.login === getEnvVar('BOT_USER_NAME')) {
-        context.github.gitdata.deleteRef(context.repo({
+        context.github.git.deleteRef(context.repo({
           ref: pr.base.ref,
         }));
       }
@@ -258,7 +258,7 @@ PR is no longer targeting this branch for a backport',
   const TROP_COMMAND_PREFIX = '/trop ';
 
   // manually trigger backporting process on trigger comment phrase
-  robot.on('issue_comment.created', async (context) => {
+  robot.on('issue_comment.created', async (context: Context) => {
     const payload = context.payload;
     const config = await context.config<TropConfig>('config.yml');
     if (!config || !Array.isArray(config.authorizedUsers)) {
@@ -288,7 +288,7 @@ PR is no longer targeting this branch for a backport',
       name: 'backport sanity checker',
       command: /^run backport/,
       execute: async () => {
-        const pr = (await context.github.pullRequests.get(
+        const pr = (await context.github.pulls.get(
           context.repo({ number: payload.issue.number }))
         ).data;
         if (!pr.merged) {
@@ -304,7 +304,7 @@ PR is no longer targeting this branch for a backport',
       name: 'backport automatically',
       command: /^run backport$/,
       execute: async () => {
-        const pr = (await context.github.pullRequests.get(
+        const pr = (await context.github.pulls.get(
           context.repo({ number: payload.issue.number }))
         ).data as any;
         await context.github.issues.createComment(context.repo({
@@ -323,7 +323,7 @@ PR is no longer targeting this branch for a backport',
           robot.log(`backport-to ${branch}`);
 
           if (!(branch.trim())) continue;
-          const pr = (await context.github.pullRequests.get(
+          const pr = (await context.github.pulls.get(
             context.repo({ number: payload.issue.number }))
           ).data;
 


### PR DESCRIPTION
Does what it says on the tin.

This is a prerequisite for using pagination when pulling down PRs, since v7 doesn't use a recent enough version of `@octokit/rest`.

cc @MarshallOfSound @ckerr