### PR TITLE
refactor: use @octokit/rest@16 pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "config-yml": "^0.10.2",
     "fs-extra": "^7.0.0",
     "node-fetch": "^2.1.1",
-    "probot": "^9.2.5",
+    "probot": "^9.2.19",
     "queue": "^4.5.0",
     "simple-git": "1.105.0",
     "what-the-diff": "^0.4.0"

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -147,6 +147,7 @@ describe('trop', () => {
 
   describe('pull_request.opened event', () => {
     it('labels the original PR when a manual backport PR has been opened', async () => {
+      github.paginate = jest.fn().mockReturnValue(Promise.resolve({ check_runs: [] }));
       await robot.receive(backportPROpenedEvent);
 
       expect(updateManualBackport).toHaveBeenCalled();

--- a/src/backport/__tests__/index.spec.ts
+++ b/src/backport/__tests__/index.spec.ts
@@ -85,7 +85,11 @@ describe('trop', () => {
         })),
       },
       checks: {
-        listForRef: jest.fn().mockReturnValue(Promise.resolve({ data: { check_runs: [] } })),
+        listForRef: {
+          endpoint: {
+            merge: jest.fn().mockReturnValue(Promise.resolve({ data: { check_runs: [] } })),
+          },
+        },
       },
     };
 

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -65,14 +65,15 @@ export const backportImpl = async (robot: Application,
   const log = (...args: string[]) => robot.log(slug, ...args);
 
   const getCheckRun = async () => {
-    const allChecks = await context.github.checks.listForRef(context.repo({
-      ref: context.payload.pull_request.head.sha,
-      per_page: 100,
-    }));
+    const baseParams = context.repo({ ref: context.payload.pull_request.head.sha });
+    const allChecks = await context.github.paginate(
+      context.github.checks.listForRef(baseParams),
+      res => res.data,
+    );
 
-    return allChecks.data.check_runs.find((run: GitHub.ChecksListForRefResponseCheckRunsItem) => {
-      return run.name === `${CHECK_PREFIX}${targetBranch}`;
-    });
+    return (allChecks as any as GitHub.ChecksListForRefResponse).check_runs.find(
+      (run: GitHub.ChecksListForRefResponseCheckRunsItem) => run.name === `${CHECK_PREFIX}${targetBranch}`,
+    );
   };
 
   let createdDir: string | null = null;

--- a/src/backport/utils.ts
+++ b/src/backport/utils.ts
@@ -64,22 +64,24 @@ export const backportImpl = async (robot: Application,
 
   const log = (...args: string[]) => robot.log(slug, ...args);
 
-  const getCheckRun = async () => {
-    const baseParams = context.repo({ ref: context.payload.pull_request.head.sha });
-    const allChecks = await context.github.paginate(
-      context.github.checks.listForRef(baseParams),
-      res => res.data,
-    );
+  const pr = context.payload.pull_request as any as PullRequest;
 
-    return (allChecks as any as GitHub.ChecksListForRefResponse).check_runs.find(
-      (run: GitHub.ChecksListForRefResponseCheckRunsItem) => run.name === `${CHECK_PREFIX}${targetBranch}`,
+  const getCheckRun = async () => {
+    const allChecks = await context.github.paginate(
+      context.github.checks.listForRef.endpoint.merge(
+        context.repo({ ref: pr.head.sha }),
+      ),
+    ) as any as GitHub.ChecksListForRefResponse;
+
+    return allChecks.check_runs.find(
+      run => run.name === `${CHECK_PREFIX}${targetBranch}`,
     );
   };
 
   let createdDir: string | null = null;
 
   queue.enterQueue(
-    `backport-${context.payload.pull_request.head.sha}-${targetBranch}-${purpose}`,
+    `backport-${pr.head.sha}-${targetBranch}-${purpose}`,
     async () => {
       log(`Executing ${bp} for "${slug}"`);
       if (purpose === BackportPurpose.Check) {
@@ -96,7 +98,6 @@ export const backportImpl = async (robot: Application,
       log('getting repo access token');
       const repoAccessToken = await getRepoToken(robot, context);
 
-      const pr = context.payload.pull_request as any as PullRequest;
       // Set up empty repo on master
       log('Setting up local repository');
       const { dir } = await initRepo({

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -1,6 +1,7 @@
 import * as labelUtils from '../utils/label-utils';
 import { PRChange, PRStatus } from '../enums';
 import { Context } from 'probot';
+import { IssuesListCommentsResponseItem } from '@octokit/rest';
 
 /*
 * Updates the labels on a backport's original PR as well as comments with links
@@ -28,10 +29,10 @@ export const updateManualBackport = async (
     }
 
     // Fetch all existing comments across pages
-    const baseParams = context.repo({ number: oldPRNumber });
-    const existingComments = await context.github.paginate(
-      context.github.issues.listComments(baseParams),
-      res => res.data,
+    const existingComments: IssuesListCommentsResponseItem[] = await context.github.paginate(
+      context.github.issues.listComments.endpoint.merge(
+        context.repo({ number: oldPRNumber }),
+      ),
     );
 
     // We should only comment if there is not a previous existing comment

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -23,11 +23,11 @@ export const labelToTargetBranch = (label: Label, prefix: string) => {
 };
 
 export const labelExistsOnPR = async (context: Context, prNumber: number, labelName: string) => {
-  const labels = await context.github.issues.listLabelsOnIssue(context.repo({
-    number: prNumber,
-    per_page: 100,
-    page: 1,
-  }));
+  const baseParams = context.repo({ number: prNumber });
+  const labels = await context.github.paginate(
+    context.github.issues.listLabelsOnIssue(baseParams),
+    res => res.data,
+  );
 
-  return labels.data.some(label => label.name === labelName);
+  return labels.some(label => label.name === labelName);
 };


### PR DESCRIPTION
Follow-up to https://github.com/electron/trop/pull/112.

We previously had an issue wherein trop would stop functioning properly after 100 pull requests owing to lack of pagination abilities.

The `.paginate` function was added in `@octokit/rest@16`, which was only rolled into `probot@9`.

Now that we have this in `master`, i've refactored our `octokit` calls to take advantage of it and thereby ameliorate the PR cap issue.

cc @electron/wg-releases @MarshallOfSound 