### PR TITLE
feat: specify manual backport opener in comment

### DIFF
--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -36,7 +36,7 @@ export const updateManualBackport = async (
     );
 
     // We should only comment if there is not a previous existing comment
-    const commentBody = `A maintainer has manually backported this PR to "${pr.base.ref}", \
+    const commentBody = `@${pr.user.login} has manually backported this PR to "${pr.base.ref}", \
 please check out #${pr.number}`;
     const shouldComment = !existingComments.some(comment => comment.body === commentBody);
 


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/121.

Changes trop's manual backport comment copy from:

> A maintainer has manually backported this PR to "BRANCH", please check out #12345

to 

> @codebytere has manually backported this PR to "BRANCH", please check out #12345

cc @MarshallOfSound 