### PR TITLE
feat: pass backport and target branch to manual backports

### DIFF
--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -54,4 +54,8 @@ please check out #${pr.number}`;
 
   await labelUtils.removeLabel(context, oldPRNumber, labelToRemove);
   await labelUtils.addLabel(context, oldPRNumber, [labelToAdd]);
+
+  // Add labels for the backport and target branch to the manual backport if
+  // the maintainer forgot to do so themselves
+  await labelUtils.addLabel(context, pr.number, ['backport', pr.base.ref]);
 };


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/119.

Add labels for the backport and target branch to the manual backport if the maintainer forgot to do so themselves.

cc @MarshallOfSound @jkleinsc 