### PR TITLE
feat: enable GHE support

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -26,6 +26,7 @@ describe('runner', () => {
   describe('initRepo()', () => {
     it('should clone a github repository', async () => {
       const dir = saveDir(await initRepo({
+        githubHost: 'github.com',
         slug: 'electron/trop',
         accessToken: '',
       }));
@@ -35,6 +36,7 @@ describe('runner', () => {
 
     it('should fail if the github repository does not exist', async () => {
       await expect(initRepo({
+        githubHost: 'github.com',
         slug: 'electron/this-is-not-trop',
         accessToken: '',
       })).rejects.toBeTruthy();

--- a/src/operations/init-repo.ts
+++ b/src/operations/init-repo.ts
@@ -7,6 +7,7 @@ import * as simpleGit from 'simple-git/promise';
 const baseDir = path.resolve(os.tmpdir(), 'trop-working');
 
 export interface InitRepoOptions {
+  githubHost: string;
   slug: string;
   accessToken: string;
 }
@@ -17,7 +18,7 @@ export interface InitRepoOptions {
 * @param {InitRepoOptions} repo and payload for repo initialization
 * @returns {Object} - an object containing the repo initialization directory
 */
-export const initRepo = async ({ slug, accessToken }: InitRepoOptions) => {
+export const initRepo = async ({ githubHost, slug, accessToken }: InitRepoOptions) => {
   await fs.mkdirp(path.resolve(baseDir, slug));
   const prefix = path.resolve(baseDir, slug, 'job-');
   const dir = await fs.mkdtemp(prefix);
@@ -30,7 +31,7 @@ export const initRepo = async ({ slug, accessToken }: InitRepoOptions) => {
   const git = simpleGit(dir);
 
   await git.clone(
-    `https://x-access-token:${accessToken}@github.com/${slug}.git`,
+    `https://x-access-token:${accessToken}@${githubHost}/${slug}.git`,
     '.',
   );
 


### PR DESCRIPTION
Hi,

This PR extracts a github endpoint as [`GHE_HOST` environment variable like probot](https://probot.github.io/docs/configuration/) to work with a github enterprise instance.

