### PR TITLE
chore: update deprecated number properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ PR is no longer targeting this branch for a backport',
           }
         } else {
           const oldPR = (await context.github.pulls.get(context.repo({
-            number: oldPRNumber,
+            pull_number: oldPRNumber,
           }))).data;
 
           // The target PR is only "good" if it was merged to master
@@ -281,7 +281,7 @@ PR is no longer targeting this branch for a backport',
 
     if (!config.authorizedUsers.includes(payload.comment.user.login)) {
       await context.github.issues.createComment(context.repo({
-        number: payload.issue.number,
+        issue_number: payload.issue.number,
         body: `@${payload.comment.user.login} is not authorized to run PR backports.`,
       }));
       return;
@@ -294,11 +294,11 @@ PR is no longer targeting this branch for a backport',
       command: /^run backport/,
       execute: async () => {
         const pr = (await context.github.pulls.get(
-          context.repo({ number: payload.issue.number }))
+          context.repo({ pull_number: payload.issue.number }))
         ).data;
         if (!pr.merged) {
           await context.github.issues.createComment(context.repo({
-            number: payload.issue.number,
+            issue_number: payload.issue.number,
             body: 'This PR has not been merged yet, and cannot be backported.',
           }));
           return false;
@@ -310,11 +310,11 @@ PR is no longer targeting this branch for a backport',
       command: /^run backport$/,
       execute: async () => {
         const pr = (await context.github.pulls.get(
-          context.repo({ number: payload.issue.number }))
+          context.repo({ pull_number: payload.issue.number }))
         ).data as any;
         await context.github.issues.createComment(context.repo({
           body: 'The backport process for this PR has been manually initiated, here we go! :D',
-          number: payload.issue.number,
+          issue_number: payload.issue.number,
         }));
         backportAllLabels(context, pr);
         return true;
@@ -329,7 +329,7 @@ PR is no longer targeting this branch for a backport',
 
           if (!(branch.trim())) continue;
           const pr = (await context.github.pulls.get(
-            context.repo({ number: payload.issue.number }))
+            context.repo({ pull_number: payload.issue.number }))
           ).data;
 
           try {
@@ -337,7 +337,7 @@ PR is no longer targeting this branch for a backport',
           } catch (err) {
             await context.github.issues.createComment(context.repo({
               body: `The branch you provided "${branch}" does not appear to exist :cry:`,
-              number: payload.issue.number,
+              issue_number: payload.issue.number,
             }));
             return true;
           }
@@ -349,7 +349,7 @@ PR is no longer targeting this branch for a backport',
             if (!supported.includes(branch)) {
               await context.github.issues.createComment(context.repo({
                 body: `${branch} is no longer supported - no backport will be initiated.`,
-                number: payload.issue.number,
+                issue_number: payload.issue.number,
               }));
               return false;
             }
@@ -358,7 +358,7 @@ PR is no longer targeting this branch for a backport',
           await context.github.issues.createComment(context.repo({
             body: `The backport process for this PR has been manually initiated -
 sending your commits to "${branch}"!`,
-            number: payload.issue.number,
+            issue_number: payload.issue.number,
           }));
           context.payload.pull_request = context.payload.pull_request || pr;
           backportToBranch(robot, context, branch);

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -34,7 +34,7 @@ please check out #${pr.number}`;
     // TODO(codebytere): Once probot updates to @octokit/rest@16 we can use .paginate to
     // get all the comments properly, for now 100 should do
     const { data: existingComments } = await context.github.issues.listComments(context.repo({
-      number: oldPRNumber,
+      issue_number: oldPRNumber,
       per_page: 100,
     }));
 
@@ -44,7 +44,7 @@ please check out #${pr.number}`;
     if (shouldComment) {
       // Comment on the original PR with the manual backport link
       await context.github.issues.createComment(context.repo({
-        number: oldPRNumber,
+        issue_number: oldPRNumber,
         body: commentBody,
       }));
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,7 @@ export const backportImpl = async (robot: Application,
     if (!supported.includes(targetBranch)) {
       await context.github.issues.createComment(context.repo({
         body: `${targetBranch} is no longer supported - no backport will be initiated.`,
-        number: context.payload.issue.number,
+        issue_number: context.payload.issue.number,
       }));
       return;
     }
@@ -151,7 +151,7 @@ export const backportImpl = async (robot: Application,
       // Get list of commits
       log(`Getting rev list from: ${pr.base.sha}..${pr.head.sha}`);
       const commits = (await context.github.pulls.listCommits(context.repo({
-        number: pr.number,
+        pull_number: pr.number,
       }))).data.map((commit: PullsListCommitsResponseItem) => commit.sha!);
 
       // No commits == WTF
@@ -164,7 +164,7 @@ export const backportImpl = async (robot: Application,
       if (commits.length >= 240) {
         log(`Too many commits (${commits.length})...backport will not be performed.`);
         await context.github.issues.createComment(context.repo({
-          number: pr.number,
+          issue_number: pr.number,
           body: 'This PR has exceeded the automatic backport commit limit \
     and must be performed manually.',
         }));
@@ -231,14 +231,14 @@ export const backportImpl = async (robot: Application,
         // request their review on the automatically backported pull request
         if (await checkUserHasWriteAccess(context, pr.user.login)) {
           await context.github.pulls.createReviewRequest(context.repo({
-            number: newPr.number,
+            pull_number: newPr.number,
             reviewers: [pr.user.login],
           }));
         }
 
         log('Adding breadcrumb comment');
         await context.github.issues.createComment(context.repo({
-          number: pr.number,
+          issue_number: pr.number,
           body: `I have automatically backported this PR to "${targetBranch}", \
     please check out #${newPr.number}`,
         }));
@@ -310,7 +310,7 @@ export const backportImpl = async (robot: Application,
       const pr = context.payload.pull_request;
       if (purpose === BackportPurpose.ExecuteBackport) {
         await context.github.issues.createComment(context.repo({
-          number: pr.number,
+          issue_number: pr.number,
           body: `I was unable to backport this PR to "${targetBranch}" cleanly;
    you will need to perform this backport manually.`,
         }) as any);

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -3,7 +3,7 @@ import { PullsGetResponseLabelsItem } from '@octokit/rest';
 
 export const addLabel = async (context: Context, prNumber: number, labelsToAdd: string[]) => {
   return context.github.issues.addLabels(context.repo({
-    number: prNumber,
+    issue_number: prNumber,
     labels: labelsToAdd,
   }));
 };
@@ -13,7 +13,7 @@ export const removeLabel = async (context: Context, prNumber: number, labelToRem
   if (!await labelExistsOnPR(context, prNumber, labelToRemove)) return;
 
   return context.github.issues.removeLabel(context.repo({
-    number: prNumber,
+    issue_number: prNumber,
     name: labelToRemove,
   }));
 };
@@ -24,7 +24,7 @@ export const labelToTargetBranch = (label: PullsGetResponseLabelsItem, prefix: s
 
 export const labelExistsOnPR = async (context: Context, prNumber: number, labelName: string) => {
   const labels = await context.github.issues.listLabelsOnIssue(context.repo({
-    number: prNumber,
+    issue_number: prNumber,
     per_page: 100,
     page: 1,
   }));


### PR DESCRIPTION
These were all deprecated per papertrail, so update them to the newer versions.

Example:
```
Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
```

cc @ckerr @MarshallOfSound @jkleinsc 