### PR TITLE
feat: allow skipping backport validity check

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const CHECK_PREFIX = 'Backportable? - ';
 
 export const NUM_SUPPORTED_VERSIONS = 4;
+
+export const SKIP_CHECK_LABEL = process.env.SKIP_CHECK_LABEL || 'backport-check-skip';


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/135.

Previously trop assumed that any branch with a parent that isn't master is a backport, which might not be the case since many dev flows break work into several branches and PR-🚂 them into one another.

This PR adds a new label that allows skipping that validity check. It defaults to `backport-check-skip`, but can be set via an environment variable `SKIP_CHECK_LABEL`. If this label is appended to a PR, the associated check for backport validity will be marked neutral.
 
cc @tommoor @MarshallOfSound @jkleinsc 