### PR TITLE
feat: allow backporting from PRs to release branches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,10 @@ PR is no longer targeting this branch for a backport',
             pull_number: oldPRNumber,
           }))).data;
 
-          // The target PR is only "good" if it was merged to master
-          if (oldPR.base.ref !== 'master') {
+          // The current PR is only valid if the PR it is backporting
+          // was merged to master or to a supported release branch.
+          const supported = await getSupportedBranches(context);
+          if (['master', ...supported].includes(oldPR.base.ref)) {
             failureCause = 'the PR that it is backporting was not targeting the master branch.';
           } else if (!oldPR.merged) {
             failureCause = 'the PR that is backporting has not been merged yet.';


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/21773.

It's not uncommon that a PR would need to directly target a release branch, and then potentially be backported to other PRs from that initial PR. This PR thus allows PRs to be marked valid as long as the PR they are backporting targeted a valid release branch.

cc @MarshallOfSound @jkleinsc @ckerr 