### PR TITLE
fix: always check for skip label on pr change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,21 +148,19 @@ PR is no longer targeting this branch for a backport',
 
         // If a branch is targeting something that isn't master it might not be a backport;
         // allow for a label to skip backport validity check for these branches.
-        if (['labeled', 'unlabeled'].includes(context.payload.action)) {
-          if (await labelExistsOnPR(context, pr.number, SKIP_CHECK_LABEL)) {
-            await context.github.checks.update(context.repo({
-              check_run_id: checkRun.id,
-              name: checkRun.name,
-              conclusion: 'neutral' as 'neutral',
-              completed_at: (new Date()).toISOString(),
-              output: {
-                title: 'Backport Check Skipped',
-                summary: 'This PR is not a backport - skip backport validation check',
-              },
-            }));
+        if (await labelExistsOnPR(context, pr.number, SKIP_CHECK_LABEL)) {
+          await context.github.checks.update(context.repo({
+            check_run_id: checkRun.id,
+            name: checkRun.name,
+            conclusion: 'neutral' as 'neutral',
+            completed_at: (new Date()).toISOString(),
+            output: {
+              title: 'Backport Check Skipped',
+              summary: 'This PR is not a backport - skip backport validation check',
+            },
+          }));
 
-            return;
-          }
+          return;
         }
 
         const FASTTRACK_PREFIXES = ['build:', 'ci:'];


### PR DESCRIPTION
Fixes an issue where when new commits were added to an existing branch, the `SKIP_CHECK_LABEL` label would not take effect. We only run this check on:

```
    [
      'pull_request.opened',
      'pull_request.edited',
      'pull_request.synchronize',
      'pull_request.labeled',
      'pull_request.unlabeled',
    ]
```

anyway, so it's fine to just run this and short-circuit potentially every time.

cc @jkleinsc @ckerr @MarshallOfSound @tommoor