### PR TITLE
feat: invalid backports are neutral instead of failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ PR is no longer targeting this branch for a backport',
           await context.github.checks.update(context.repo({
             check_run_id: checkRun.id,
             name: checkRun.name,
-            conclusion: 'failure' as 'failure',
+            conclusion: 'neutral' as 'neutral',
             completed_at: (new Date()).toISOString(),
             details_url: 'https://github.com/electron/trop/blob/master/docs/manual-backports.md',
             output: {


### PR DESCRIPTION
Marking the build failed because it's missing a backport annotation obscures the CI status in the PR list, and there are many valid reasons to have PRs targeting non-master branches that aren't direct backports.

Most recently: https://github.com/electron/electron/pull/22943