### PR TITLE
fix: ignore target labels on manual backports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { getSupportedBranches } from './utils/branch-util';
 const probotHandler = async (robot: Application) => {
   const labelMergedPRs = async (context: Context, pr: PullsGetResponse) => {
     for (const label of pr.labels) {
-      const targetBranch = label.name.match(/(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))/);
+      const targetBranch = label.name.match(/^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/);
       if (targetBranch && targetBranch[0]) {
         await labelMergedPR(context, pr, label.name);
       }


### PR DESCRIPTION
Fix for the struggle [seen here](https://github.com/electron/electron/pull/23153).

When manual backports are merged, it looks for the `x-y-z` label on the manual backport PR, and then updates the original PR with `merged/x-y-x`. However, if someone tries to tag a manual backport _itself_ for backports, the `target/x-y-z` labels also get caught up in the regex, and then are appended unexpectedly to the original PR. This stops that from happening by ensuring that no labels are caught which are not _only_ `x-y-z`.

In an ideal world, it adds `needs-manual` to the original PR, but i'll get that as a follow-up.

cc @MarshallOfSound 