### PR TITLE
fix: update labels properly on combo backport merges

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,5 @@ export const CHECK_PREFIX = 'Backportable? - ';
 export const NUM_SUPPORTED_VERSIONS = 4;
 
 export const SKIP_CHECK_LABEL = process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
+
+export const BACKPORT_PATTERN = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/gim;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,3 @@ export const CHECK_PREFIX = 'Backportable? - ';
 export const NUM_SUPPORTED_VERSIONS = 4;
 
 export const SKIP_CHECK_LABEL = process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
-
-export const BACKPORT_PATTERN = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/gim;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,13 @@ import { Application, Context } from 'probot';
 import { backportImpl, labelMergedPR } from './utils';
 import { labelToTargetBranch, labelExistsOnPR } from './utils/label-utils';
 import { TropConfig } from './interfaces';
-import { CHECK_PREFIX, SKIP_CHECK_LABEL, BACKPORT_PATTERN } from './constants';
+import { CHECK_PREFIX, SKIP_CHECK_LABEL } from './constants';
 import { getEnvVar } from './utils/env-util';
 import { PRChange, PRStatus, BackportPurpose } from './enums';
 import { ChecksListForRefResponseCheckRunsItem, PullsGetResponse } from '@octokit/rest';
 import { backportToLabel, backportToBranch } from './operations/backport-to-location';
 import { updateManualBackport } from './operations/update-manual-backport';
-import { getSupportedBranches } from './utils/branch-util';
+import { getSupportedBranches, getBackportPattern } from './utils/branch-util';
 
 const probotHandler = async (robot: Application) => {
   const labelMergedPRs = async (context: Context, pr: PullsGetResponse) => {
@@ -97,9 +97,10 @@ PR is no longer targeting this branch for a backport',
     const backportNumbers: number[] = [];
 
     if (pr.user.login !== getEnvVar('BOT_USER_NAME')) {
+      const backportPattern = getBackportPattern();
       // Check if this PR is a manual backport of another PR.
       let match: RegExpExecArray | null;
-      while (match = BACKPORT_PATTERN.exec(pr.body)) {
+      while (match = backportPattern.exec(pr.body)) {
         // This might be the first or second capture group depending on if it's a link or not.
         backportNumbers.push(!!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ PR is no longer targeting this branch for a backport',
       let match: RegExpExecArray | null;
       while (match = backportPattern.exec(pr.body)) {
         // This might be the first or second capture group depending on if it's a link or not.
-        backportNumbers.push(!!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
+        backportNumbers.push(match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Application, Context } from 'probot';
 import { backportImpl, labelMergedPR } from './utils';
 import { labelToTargetBranch, labelExistsOnPR } from './utils/label-utils';
 import { TropConfig } from './interfaces';
-import { CHECK_PREFIX, SKIP_CHECK_LABEL } from './constants';
+import { CHECK_PREFIX, SKIP_CHECK_LABEL, BACKPORT_PATTERN } from './constants';
 import { getEnvVar } from './utils/env-util';
 import { PRChange, PRStatus, BackportPurpose } from './enums';
 import { ChecksListForRefResponseCheckRunsItem, PullsGetResponse } from '@octokit/rest';
@@ -98,9 +98,8 @@ PR is no longer targeting this branch for a backport',
 
     if (pr.user.login !== getEnvVar('BOT_USER_NAME')) {
       // Check if this PR is a manual backport of another PR.
-      const backportPattern = /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/gim;
       let match: RegExpExecArray | null;
-      while (match = backportPattern.exec(pr.body)) {
+      while (match = BACKPORT_PATTERN.exec(pr.body)) {
         // This might be the first or second capture group depending on if it's a link or not.
         backportNumbers.push(!!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const labelMergedPR = async (context: Context, pr: PullsGetResponse, targ
   const backportPattern = getBackportPattern();
   while (match = backportPattern.exec(pr.body)) {
     // This might be the first or second capture group depending on if it's a link or not.
-    backportNumbers.push(!!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
+    backportNumbers.push(match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
   }
 
   for (const prNumber of backportNumbers) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ import { IQueue } from 'queue';
 import * as simpleGit from 'simple-git/promise';
 
 import queue from './Queue';
-import { CHECK_PREFIX, BACKPORT_PATTERN } from './constants';
+import { CHECK_PREFIX } from './constants';
 import { PRStatus, BackportPurpose } from './enums';
 
 import * as labelUtils from './utils/label-utils';
@@ -20,7 +20,7 @@ import { initRepo } from './operations/init-repo';
 import { setupRemotes } from './operations/setup-remotes';
 import { backportCommitsToBranch } from './operations/backport-commits';
 import { getRepoToken } from './utils/token-util';
-import { getSupportedBranches } from './utils/branch-util';
+import { getSupportedBranches, getBackportPattern } from './utils/branch-util';
 import { getEnvVar } from './utils/env-util';
 
 const makeQueue: IQueue = require('queue');
@@ -29,7 +29,8 @@ const { parse: parseDiff } = require('what-the-diff');
 export const labelMergedPR = async (context: Context, pr: PullsGetResponse, targetBranch: String) => {
   const backportNumbers: number[] = [];
   let match: RegExpExecArray | null;
-  while (match = BACKPORT_PATTERN.exec(pr.body)) {
+  const backportPattern = getBackportPattern();
+  while (match = backportPattern.exec(pr.body)) {
     // This might be the first or second capture group depending on if it's a link or not.
     backportNumbers.push(!!match[1] ? parseInt(match[1], 10) : parseInt(match[2], 10));
   }

--- a/src/utils/branch-util.ts
+++ b/src/utils/branch-util.ts
@@ -30,3 +30,10 @@ export async function getSupportedBranches(context: Context): Promise<string[]> 
   const values = Object.values(filtered);
   return values.sort().slice(-NUM_SUPPORTED_VERSIONS);
 }
+
+/**
+ * @returns A scoped Regex matching the backport pattern present in PR bodies.
+ */
+export const getBackportPattern = () => {
+  return /(?:^|\n)(?:manual |manually )?backport.*(?:#(\d+)|\/pull\/(\d+))/gim;
+};


### PR DESCRIPTION
Refs https://github.com/electron/trop/pull/148.

Ensure that when combination backports are merged, the `in-flight/<branch>` labels are updated to  `merged/<branch>` for all initial PRs in the combo.

cc @MarshallOfSound 