### PR TITLE
fix: endless queued Valid Backport Check

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -22,3 +22,9 @@ export enum PRStatus {
   IN_FLIGHT = 'in-flight/',
   NEEDS_MANUAL = 'needs-manual-bp/',
 }
+
+export enum CheckRunStatus {
+  NEUTRAL = 'neutral',
+  FAILURE = 'failure',
+  SUCCESS = 'success',
+}

--- a/src/utils/checks-util.ts
+++ b/src/utils/checks-util.ts
@@ -1,0 +1,25 @@
+import { Context } from 'probot';
+import { CheckRunStatus } from '../enums';
+import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
+
+export async function updateBackportValidityCheck(
+  context: Context,
+  checkRun: ChecksListForRefResponseCheckRunsItem,
+  statusItems: {
+    conclusion: CheckRunStatus,
+    title: string
+    summary: string,
+  },
+) {
+  await context.github.checks.update(context.repo({
+    check_run_id: checkRun.id,
+    name: checkRun.name,
+    conclusion: statusItems.conclusion as CheckRunStatus,
+    completed_at: (new Date()).toISOString(),
+    details_url: 'https://github.com/electron/trop/blob/master/docs/manual-backports.md',
+    output: {
+      title: statusItems.title,
+      summary: statusItems.summary,
+    },
+  }));
+}


### PR DESCRIPTION
Fixes an issue where valid backports would show up as endlessly queued:

<img width="866" alt="Screen Shot 2020-05-15 at 9 07 54 AM" src="https://user-images.githubusercontent.com/2036040/82071931-a0c35d80-968b-11ea-924a-5bd61bea46e9.png">

owing to a condition oversight in fast-track PRs. This also refactors out the check update code to make it a little more organized.

cc @MarshallOfSound 