### PR TITLE
fix: sort branches by number not by string

### DIFF
--- a/src/utils/branch-util.ts
+++ b/src/utils/branch-util.ts
@@ -23,12 +23,20 @@ export async function getSupportedBranches(context: Context): Promise<string[]> 
 
   const releaseBranches = branches.filter(branch => branch.name.match(SUPPORTED_BRANCH_PATTERN));
   const filtered: Record<string, string> = {};
-  releaseBranches.sort().forEach((branch) => {
-    return filtered[branch.name.split('-')[0]] = branch.name;
+  releaseBranches.sort((a, b) => {
+    const aParts = a.name.split('-');
+    const bParts = b.name.split('-');
+    for (let i = 0; i < aParts.length; i += 1) {
+      if (aParts[i] === bParts[i]) continue;
+      return parseInt(aParts[i], 10) - parseInt(bParts[i], 10);
+    }
+    return 0;
+  }).forEach((branch) => {
+    return (filtered[branch.name.split('-')[0]] = branch.name);
   });
 
   const values = Object.values(filtered);
-  return values.sort().slice(-NUM_SUPPORTED_VERSIONS);
+  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-NUM_SUPPORTED_VERSIONS);
 }
 
 /**


### PR DESCRIPTION
`10-x-y < 9-x-y` in string comparisons.

cc @MarshallOfSound 