### PR TITLE
feat: automatically label semver-minor pr backports

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,6 @@ export const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 4;
 
 export const SKIP_CHECK_LABEL =
   process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
+
+export const BACKPORT_REQUESTED_LABEL =
+  process.env.BACKPORT_REQUESTED_LABEL || 'backport/requested 🗳';


### PR DESCRIPTION
Automatically label semver-minor PRs being backported with the `backport/requested` label.

cc @MarshallOfSound @jkleinsc 