### PR TITLE
fix: remove in-flight label when PRs are closed

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,5 +1,6 @@
 export enum PRChange {
   OPEN,
+  MERGE,
   CLOSE,
 }
 

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -70,7 +70,7 @@ please check out #${pr.number}`;
         }),
       );
     }
-  } else {
+  } else if (PRChange.MERGE) {
     log(
       'updateManualBackport',
       LogLevel.INFO,
@@ -79,10 +79,23 @@ please check out #${pr.number}`;
 
     labelToRemove = PRStatus.IN_FLIGHT + pr.base.ref;
     labelToAdd = PRStatus.MERGED + pr.base.ref;
+  } else {
+    log(
+      'updateManualBackport',
+      LogLevel.INFO,
+      `Backport of ${oldPRNumber} at #${pr.number} to ${pr.base.ref} was closed`,
+    );
+
+    // If a backport is closed with unmerged commits, we just want
+    // to remove the old in-flight/<branch> label.
+    labelToRemove = PRStatus.IN_FLIGHT + pr.base.ref;
   }
 
   await labelUtils.removeLabel(context, oldPRNumber, labelToRemove);
-  await labelUtils.addLabel(context, oldPRNumber, [labelToAdd]);
+
+  if (labelToAdd) {
+    await labelUtils.addLabel(context, oldPRNumber, [labelToAdd]);
+  }
 
   // Add labels for the backport and target branch to the manual backport if
   // the maintainer forgot to do so themselves

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,11 @@ export const labelMergedPR = async (
 };
 
 const isSemverMinorPR = async (context: Context, pr: PullsGetResponse) => {
-  log('isSemverMinorPR', LogLevel.INFO, `Checking if #${pr.number} is semver-minor`);
+  log(
+    'isSemverMinorPR',
+    LogLevel.INFO,
+    `Checking if #${pr.number} is semver-minor`,
+  );
   const SEMVER_MINOR_LABEL = 'semver-minor';
 
   const hasPrefix = pr.title.startsWith('feat:');
@@ -354,7 +358,11 @@ export const backportImpl = async (
         const labelsToAdd = ['backport', `${targetBranch}`];
 
         if (await isSemverMinorPR(context, pr)) {
-          log('backportImpl', LogLevel.INFO, `Determined that ${pr.number} is semver-minor`);
+          log(
+            'backportImpl',
+            LogLevel.INFO,
+            `Determined that ${pr.number} is semver-minor`,
+          );
           labelsToAdd.push(BACKPORT_REQUESTED_LABEL);
         }
 


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/140.

Previously, when manual backports were closed but not merged, the `in-flight` label would never be removed. This ensures that it is now removed when manual backports are closed with unmerged commits.