### PR TITLE
fix: delete proper ref

### DIFF
--- a/spec/fixtures/backport_pull_request.closed.bot.json
+++ b/spec/fixtures/backport_pull_request.closed.bot.json
@@ -9,7 +9,7 @@
       "user": {
         "login": "trop[bot]"
       },
-      "base": {
+      "head": {
         "ref": "123456789iuytdxcvbnjhfdriuyfedfgy54escghjnbg"
       },
       "body": "Backport of #14\n\nSee that PR for details.\n\n\r\nNotes: <!-- One-line Change Summary Here-->",

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -64,14 +64,6 @@ describe('trop', () => {
           Promise.resolve({
             data: {
               merged: true,
-              base: {
-                repo: {
-                  name: 'test',
-                  owner: {
-                    login: 'codebytere',
-                  },
-                },
-              },
               head: {
                 sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
               },

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,13 +340,13 @@ const probotHandler = async (robot: Application) => {
         robot.log(`Labeling original PR for merged PR: #${pr.number}`);
         await labelMergedPRs(context, pr);
 
-        robot.log(`Deleting base branch: ${pr.base.ref}`);
+        robot.log(`Deleting base branch: ${pr.head.ref}`);
         try {
           await context.github.git.deleteRef(
-            context.repo({ ref: pr.base.ref }),
+            context.repo({ ref: `heads/${pr.head.ref}` }),
           );
         } catch (e) {
-          robot.log('Failed to delete base branch: ', e);
+          robot.log('Failed to delete backport branch: ', e);
         }
       } else {
         robot.log(

--- a/src/operations/backport-to-location.ts
+++ b/src/operations/backport-to-location.ts
@@ -20,7 +20,7 @@ export const backportToLabel = async (
   log(
     'backportToLabel',
     LogLevel.INFO,
-    `Executing backport to branch from label ${label}`,
+    `Executing backport to branch from label ${label.name}`,
   );
 
   if (!label.name.startsWith(PRStatus.TARGET)) {


### PR DESCRIPTION
Delete correct branch when a trop PR is merged.

Error seen [here](https://my.papertrailapp.com/systems/electron-trop/events?focus=1254944350363930706&selected=1254944350363930706) - we were previously trying to delete the base branch e.g `10-x-y` instead of the head branch e.g `backport-to-10-x-y`.

cc @MarshallOfSound @jkleinsc  