### PR TITLE
fix: labels when trop PR closed unmerged

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -181,10 +181,10 @@ describe('trop', () => {
     });
 
     it('adds a label when a backport PR has been merged', async () => {
-      Object.defineProperty(utils, 'labelMergedPR', { value: jest.fn() });
+      Object.defineProperty(utils, 'labelClosedPR', { value: jest.fn() });
       await robot.receive(backportPRClosedBotEvent);
 
-      expect(utils.labelMergedPR).toHaveBeenCalled();
+      expect(utils.labelClosedPR).toHaveBeenCalled();
     });
 
     it('labels the original PR when a manual backport PR has been merged', async () => {
@@ -194,7 +194,7 @@ describe('trop', () => {
     });
 
     it('adds a label when a backport PR has been merged', async () => {
-      Object.defineProperty(utils, 'labelMergedPR', { value: jest.fn() });
+      Object.defineProperty(utils, 'labelClosedPR', { value: jest.fn() });
       await robot.receive(backportPRClosedEvent);
 
       expect(updateManualBackport).toHaveBeenCalled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Application, Context } from 'probot';
 
-import { backportImpl, labelMergedPR } from './utils';
+import { backportImpl, labelClosedPR } from './utils';
 import { labelToTargetBranch, labelExistsOnPR } from './utils/label-utils';
 import { TropConfig } from './interfaces';
 import { CHECK_PREFIX, SKIP_CHECK_LABEL } from './constants';
@@ -19,13 +19,17 @@ import { getSupportedBranches, getBackportPattern } from './utils/branch-util';
 import { updateBackportValidityCheck } from './utils/checks-util';
 
 const probotHandler = async (robot: Application) => {
-  const labelMergedPRs = async (context: Context, pr: PullsGetResponse) => {
+  const labelClosedPRs = async (
+    context: Context,
+    pr: PullsGetResponse,
+    change: PRChange,
+  ) => {
     for (const label of pr.labels) {
       const targetBranch = label.name.match(
         /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/,
       );
       if (targetBranch && targetBranch[0]) {
-        await labelMergedPR(context, pr, label.name);
+        await labelClosedPR(context, pr, label.name, change);
       }
     }
   };
@@ -327,20 +331,19 @@ const probotHandler = async (robot: Application) => {
     if (pr.merged) {
       if (oldPRNumbers.length > 0) {
         robot.log(`Automatic backport merged for: #${pr.number}`);
-
         robot.log(`Labeling original PR for merged PR: #${pr.number}`);
         for (const oldPRNumber of oldPRNumbers) {
           await updateManualBackport(context, PRChange.MERGE, oldPRNumber);
         }
-        await labelMergedPRs(context, pr);
+        await labelClosedPRs(context, pr, PRChange.MERGE);
       }
 
       // Check that the closed PR is trop's own and act accordingly.
       if (pr.user.login === getEnvVar('BOT_USER_NAME')) {
         robot.log(`Labeling original PR for merged PR: #${pr.number}`);
-        await labelMergedPRs(context, pr);
+        await labelClosedPRs(context, pr, PRChange.MERGE);
 
-        robot.log(`Deleting base branch: ${pr.head.ref}`);
+        robot.log(`Deleting head branch: ${pr.head.ref}`);
         try {
           await context.github.git.deleteRef(
             context.repo({ ref: `heads/${pr.head.ref}` }),
@@ -355,16 +358,35 @@ const probotHandler = async (robot: Application) => {
         backportAllLabels(context, pr);
       }
     } else {
-      if (oldPRNumbers.length > 0) {
-        robot.log(
-          `Automatic backport #${pr.number} closed with unmerged commits`,
-        );
+      robot.log(
+        `Automatic backport #${pr.number} closed with unmerged commits`,
+      );
 
+      if (oldPRNumbers.length > 0) {
         robot.log(`Updating label on original PR for closed PR: #${pr.number}`);
         for (const oldPRNumber of oldPRNumbers) {
           await updateManualBackport(context, PRChange.CLOSE, oldPRNumber);
         }
-        await labelMergedPRs(context, pr);
+        await labelClosedPRs(context, pr, PRChange.CLOSE);
+      }
+
+      // Check that the closed PR is trop's own and act accordingly.
+      if (pr.user.login === getEnvVar('BOT_USER_NAME')) {
+        robot.log(`Updating labels for closed PR: #${pr.number}`);
+        await labelClosedPRs(context, pr, PRChange.CLOSE);
+        robot.log(`Deleting head branch: ${pr.head.ref}`);
+        try {
+          await context.github.git.deleteRef(
+            context.repo({ ref: `heads/${pr.head.ref}` }),
+          );
+        } catch (e) {
+          robot.log('Failed to delete backport branch: ', e);
+        }
+      } else {
+        robot.log(
+          `Backporting #${pr.number} to all branches specified by labels`,
+        );
+        backportAllLabels(context, pr);
       }
     }
   });


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/162

Previously when trop backport was closed, trop would keep the in-flight label rather than removing it. This was occurring because we were lacking logic to handle non-manual backport being closed with unmerged commits.

cc @codebytere 