### PR TITLE
test: improve trop labeling specs

### DIFF
--- a/spec/fixtures/backport_pull_request.closed.json
+++ b/spec/fixtures/backport_pull_request.closed.json
@@ -4,35 +4,28 @@
     "action": "closed",
     "number": 15,
     "pull_request": {
-      "number": 15,
       "state": "closed",
-      "locked": false,
-      "title": "mirror (backport: 4-0-x)",
+      "title": "mirror",
       "user": {
         "login": "codebytere"
       },
-      "base": {
+      "head": {
         "ref": "123456789iuytdxcvbnjhfdriuyfedfgy54escghjnbg"
       },
-      "body": "Backport of #14\n\nSee that PR for details.\n\n\r\nNotes: <!-- One-line Change Summary Here-->",
+      "body": "Backport of #14\nSee that PR for details.\nNotes: <!-- One-line Change Summary Here-->",
       "created_at": "2018-11-01T17:29:51Z",
       "merged_at": "2018-11-01T17:30:11Z",
       "labels": [
         {
           "name": "4-0-x",
           "color": "ededed"
+        }, 
+        {
+          "name": "backport",
+          "color": "ededed"
         }
       ],
-      "merged": true,
-      "merged_by": {
-        "login": "codebytere"
-      }
-    },
-    "repository": {
-      "name": "electron",
-      "owner": {
-        "login": "codebytere"
-      }
+      "merged": false
     }
   }
 }

--- a/spec/fixtures/backport_pull_request.merged.bot.json
+++ b/spec/fixtures/backport_pull_request.merged.bot.json
@@ -17,7 +17,7 @@
       "merged_at": "2018-11-01T17:30:11Z",
       "labels": [
         {
-          "name": "5-0-x",
+          "name": "4-0-x",
           "color": "ededed"
         },
         {
@@ -25,7 +25,7 @@
           "color": "ededed"
         }
       ],
-      "merged": false
+      "merged": true
     }
   }
 }

--- a/spec/fixtures/backport_pull_request.merged.json
+++ b/spec/fixtures/backport_pull_request.merged.json
@@ -7,7 +7,7 @@
       "state": "closed",
       "title": "mirror",
       "user": {
-        "login": "trop[bot]"
+        "login": "codebytere"
       },
       "head": {
         "ref": "123456789iuytdxcvbnjhfdriuyfedfgy54escghjnbg"
@@ -17,15 +17,15 @@
       "merged_at": "2018-11-01T17:30:11Z",
       "labels": [
         {
-          "name": "5-0-x",
+          "name": "4-0-x",
           "color": "ededed"
-        },
+        }, 
         {
           "name": "backport",
           "color": "ededed"
         }
       ],
-      "merged": false
+      "merged": true
     }
   }
 }


### PR DESCRIPTION
Improve labeling specs for trop. Check correct paths are taken for PRs closed with unmerged commit vs merged.

cc @mlaurencin @MarshallOfSound 