### PR TITLE
fix: make backport-to more flexible

### DIFF
--- a/spec/fixtures/issue_comment_backport_to_multiple_spaces.created.json
+++ b/spec/fixtures/issue_comment_backport_to_multiple_spaces.created.json
@@ -1,0 +1,42 @@
+{
+  "name": "issue_comment",
+  "payload": {
+    "action": "created",
+    "issue": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pull/1234",
+      "html_url": "https://github.com/codebytere/public-repo/pull/1234",
+      "number": 1234,
+      "title": "Spelling error in the README file",
+      "user": {
+        "login": "codebytere"
+      },
+      "labels": [
+        {
+          "url": "https://api.github.com/repos/codebytere/public-repo/labels/target/X-X-X",
+          "name": "target/X-X-X",
+          "color": "fc2929"
+        }
+      ],
+      "body": "It looks like you accidently spelled 'commit' with two 't's."
+    },
+    "comment": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pulls/comments/123456789",
+      "html_url": "https://github.com/codebytere/public-repo/pulls/2#issuecomment-123456789",
+      "id": 99262140,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "/trop run backport-to thingy1, thingy2, thingy3"
+    },
+    "repository": {
+      "name": "public-repo",
+      "full_name": "codebytere/public-repo",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -17,6 +17,7 @@ const prClosedEvent = require('./fixtures/pull_request.closed.json');
 const issueCommentBackportCreatedEvent = require('./fixtures/issue_comment_backport.created.json');
 const issueCommentBackportToCreatedEvent = require('./fixtures/issue_comment_backport_to.created.json');
 const issueCommentBackportToMultipleCreatedEvent = require('./fixtures/issue_comment_backport_to_multiple.created.json');
+const issueCommentBackportToMultipleCreatedSpacesEvent = require('./fixtures/issue_comment_backport_to_multiple_spaces.created.json');
 
 const backportPRMergedBotEvent = require('./fixtures/backport_pull_request.merged.bot.json');
 const backportPRClosedBotEvent = require('./fixtures/backport_pull_request.closed.bot.json');
@@ -159,6 +160,14 @@ describe('trop', () => {
       expect(github.pulls.get).toHaveBeenCalledTimes(3);
       expect(github.issues.createComment).toHaveBeenCalledTimes(2);
       expect(backportToBranch).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows for multiple PRs to be triggered in the same comment with space-separated branches', async () => {
+      await robot.receive(issueCommentBackportToMultipleCreatedSpacesEvent);
+
+      expect(github.pulls.get).toHaveBeenCalledTimes(4);
+      expect(github.issues.createComment).toHaveBeenCalledTimes(3);
+      expect(backportToBranch).toHaveBeenCalledTimes(3);
     });
 
     it('does not trigger the backport on comment to a targeted branch if the branch does not exist', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -474,12 +474,12 @@ const probotHandler = async (robot: Application) => {
       },
       {
         name: 'backport to branch',
-        command: /^run backport-to ([^\s:]+)/,
+        command: /^run backport-to (([^,]*)(, ?([^,]*))*)/,
         execute: async (targetBranches: string) => {
-          const branches = targetBranches.split(',');
+          const branches = targetBranches.split(',').map((b) => b.trim());
           for (const branch of branches) {
             robot.log(
-              `Initiatating backport to ${branch} from 'backport-to' comment`,
+              `Initiating backport to ${branch} from 'backport-to' comment`,
             );
 
             if (!branch.trim()) continue;


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/26586.

Previously, backport trigger comments needed to be:
```
/trop run backport-to 12-x-y,11-x-y,10-x-y
```

and if the branches has spaces between them the first branch would work but the latter two would silently fail. This makes the process more flexible by also allowing space-separated branches:

```
/trop run backport-to 12-x-y, 11-x-y, 10-x-y
```