### PR TITLE
feat: copy semver/* labels from the original PR to the backported PR

### DIFF
--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -99,5 +99,14 @@ please check out #${pr.number}`;
 
   // Add labels for the backport and target branch to the manual backport if
   // the maintainer forgot to do so themselves
-  await labelUtils.addLabel(context, pr.number, ['backport', pr.base.ref]);
+  const extraLabels: string[] = [];
+  const semverLabel = pr.labels.find((l: any) => l.name.startsWith('semver/'));
+  if (semverLabel) {
+    extraLabels.push(semverLabel.name);
+  }
+  await labelUtils.addLabel(context, pr.number, [
+    'backport',
+    pr.base.ref,
+    ...extraLabels,
+  ]);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -382,6 +382,13 @@ export const backportImpl = async (
           labelsToAdd.push(BACKPORT_REQUESTED_LABEL);
         }
 
+        const semverLabel = pr.labels.find((l: any) =>
+          l.name.startsWith('semver/'),
+        );
+        if (semverLabel) {
+          labelsToAdd.push(semverLabel.name);
+        }
+
         await labelUtils.addLabel(context, newPr.number!, labelsToAdd);
 
         log('backportImpl', LogLevel.INFO, 'Backport process complete');


### PR DESCRIPTION
As in title, now these labels are required our bots should automatically add these labels where appropriate.