### PR TITLE
fix: trop backporting on close unmerged

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,13 @@ export const labelClosedPR = async (
     );
   }
 
+  if (change === PRChange.CLOSE) {
+    const targetLabel = PRStatus.TARGET + targetBranch;
+    if (labelUtils.labelExistsOnPR(context, pr.number, targetLabel)) {
+      await labelUtils.removeLabel(context, pr.number, targetLabel);
+    }
+  }
+
   for (const prNumber of backportNumbers) {
     const labelToRemove = PRStatus.IN_FLIGHT + targetBranch;
 


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/174.

If a pr is closed with unmerged commits and it's a PR to master (e.g. not a backport) then trop should handle label updates and nothing else.