### PR TITLE
fix: label manual backports with semver labels

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,10 @@ export const CHECK_PREFIX = 'Backportable? - ';
 
 export const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 4;
 
+export const BACKPORT_LABEL = 'backport';
+
+export const SEMVER_PREFIX = 'semver/';
+
 export const SKIP_CHECK_LABEL =
   process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,13 +269,11 @@ const probotHandler = async (robot: Application) => {
 
           for (const oldPRNumber of oldPRNumbers) {
             robot.log(`Checking validity of #${oldPRNumber}`);
-            const oldPR = (
-              await context.github.pulls.get(
-                context.repo({
-                  pull_number: oldPRNumber,
-                }),
-              )
-            ).data;
+            const { data: oldPR } = await context.github.pulls.get(
+              context.repo({
+                pull_number: oldPRNumber,
+              }),
+            );
 
             // The current PR is only valid if the PR it is backporting
             // was merged to master or to a supported release branch.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,8 @@ import {
   CHECK_PREFIX,
   BACKPORT_REQUESTED_LABEL,
   DEFAULT_BACKPORT_REVIEW_TEAM,
+  BACKPORT_LABEL,
+  SEMVER_PREFIX,
 } from './constants';
 import { PRStatus, BackportPurpose, LogLevel, PRChange } from './enums';
 
@@ -65,7 +67,7 @@ export const labelClosedPR = async (
 
     if (change === PRChange.MERGE) {
       const labelToAdd = PRStatus.MERGED + targetBranch;
-      await labelUtils.addLabel(context, prNumber, [labelToAdd]);
+      await labelUtils.addLabels(context, prNumber, [labelToAdd]);
     }
 
     await labelUtils.removeLabel(context, prNumber, labelToRemove);
@@ -384,11 +386,11 @@ export const backportImpl = async (
           await labelUtils.removeLabel(context, pr.number, labelToRemove);
         }
 
-        if (labelToAdd) {
-          await labelUtils.addLabel(context, pr.number, [labelToAdd]);
-        }
-
-        const labelsToAdd = ['backport', `${targetBranch}`];
+        const labelsToAdd = [
+          BACKPORT_LABEL,
+          `${targetBranch}`,
+          ...(labelToAdd ? [labelToAdd] : []),
+        ];
 
         if (await isSemverMinorPR(context, pr)) {
           log(
@@ -400,13 +402,13 @@ export const backportImpl = async (
         }
 
         const semverLabel = pr.labels.find((l: any) =>
-          l.name.startsWith('semver/'),
+          l.name.startsWith(SEMVER_PREFIX),
         );
         if (semverLabel) {
           labelsToAdd.push(semverLabel.name);
         }
 
-        await labelUtils.addLabel(context, newPr.number!, labelsToAdd);
+        await labelUtils.addLabels(context, newPr.number!, labelsToAdd);
 
         log('backportImpl', LogLevel.INFO, 'Backport process complete');
       }
@@ -486,7 +488,7 @@ export const backportImpl = async (
         await labelUtils.removeLabel(context, pr.number, labelToRemove);
 
         const labelToAdd = PRStatus.NEEDS_MANUAL + targetBranch;
-        await labelUtils.addLabel(context, pr.number, [labelToAdd]);
+        await labelUtils.addLabels(context, pr.number, [labelToAdd]);
       }
 
       if (purpose === BackportPurpose.Check) {

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -3,7 +3,7 @@ import { PullsGetResponseLabelsItem } from '@octokit/rest';
 import { log } from './log-util';
 import { LogLevel } from '../enums';
 
-export const addLabel = async (
+export const addLabels = async (
   context: Context,
   prNumber: number,
   labelsToAdd: string[],


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/176.

Cleans up some labeling logic and fixes an issue with manual backports not having semver labels applied.