### PR TITLE
fix: backport label applied to backport not original

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -389,11 +389,11 @@ export const backportImpl = async (
           await labelUtils.removeLabel(context, pr.number, labelToRemove);
         }
 
-        const labelsToAdd = [
-          BACKPORT_LABEL,
-          `${targetBranch}`,
-          ...(labelToAdd ? [labelToAdd] : []),
-        ];
+        if (labelToAdd) {
+          await labelUtils.addLabels(context, pr.number!, [labelToAdd]);
+        }
+
+        const labelsToAdd = [BACKPORT_LABEL, `${targetBranch}`];
 
         if (await isSemverMinorPR(context, pr)) {
           log(


### PR DESCRIPTION
Fixes issue seen https://github.com/electron/electron/pull/27224 introduced by https://github.com/electron/trop/commit/55615207c16c69abaa89b0493ed42703c675a110.

cc @MarshallOfSound @jkleinsc 