### PR TITLE
fix: check stall when both pick approaches failed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -481,14 +481,13 @@ export const backportImpl = async (
         });
       }
 
-      // Bail if neither succeeded.
+      // Note if neither succeeded.
       if (!success) {
         log(
           'backportImpl',
           LogLevel.ERROR,
           `Cherry picking commits to branch failed`,
         );
-        return;
       }
 
       if (purpose === BackportPurpose.ExecuteBackport) {


### PR DESCRIPTION
Seen here: https://github.com/electron/electron/pull/28150

When both individual cherry-picking and squash commit picking failed we were early-returning which prevented the GitHub Check update from finishing and reflecting the failure.

cc @MarshallOfSound @jkleinsc 