### PR TITLE
chore: skip explicit checkout of master

### DIFF
--- a/src/operations/init-repo.ts
+++ b/src/operations/init-repo.ts
@@ -42,7 +42,6 @@ export const initRepo = async ({ slug, accessToken }: InitRepoOptions) => {
     await fs.remove(path.resolve(dir, file));
   }
 
-  await git.checkout('master');
   await git.pull();
   await git.addConfig('user.email', config.tropEmail || 'trop@example.com');
   await git.addConfig('user.name', config.tropName || 'Trop Bot');


### PR DESCRIPTION
No need to explicitly checkout the default branch, it should be automatically
checked out by `git pull`.
