### PR TITLE
fix: ensure the temporary branch is in a clean state before backporting

### DIFF
--- a/src/operations/backport-commits.ts
+++ b/src/operations/backport-commits.ts
@@ -27,6 +27,18 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
   try {
     await git.checkout(`target_repo/${options.targetBranch}`);
     await git.pull('target_repo', options.targetBranch);
+    if (
+      Object.keys((await git.branchLocal()).branches).includes(
+        options.tempBranch,
+      )
+    ) {
+      log(
+        'backportCommitsToBranch',
+        LogLevel.INFO,
+        `The provided temporary branch name "${options.tempBranch}" already exists, deleting existing ref before backporting`,
+      );
+      await git.deleteLocalBranch(options.tempBranch);
+    }
     await git.checkoutBranch(
       options.tempBranch,
       `target_repo/${options.targetBranch}`,


### PR DESCRIPTION
Previously we re-used a potentially dirty cherry-pick branch across cherry-pick strategies.  This ensures that if the branch exists we delete it before continuing.