### PR TITLE
fix: add missing 'await' prefix when calling async

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,7 +491,7 @@ const probotHandler = async (robot: Application) => {
     if (!cmd.startsWith(TROP_COMMAND_PREFIX)) return;
 
     // Allow all users with push access to handle backports.
-    if (!isAuthorizedUser(context, comment.user.login)) {
+    if (!(await isAuthorizedUser(context, comment.user.login))) {
       robot.log(
         `@${comment.user.login} is not authorized to run PR backports - stopping`,
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export const labelClosedPR = async (
 
   if (change === PRChange.CLOSE) {
     const targetLabel = PRStatus.TARGET + targetBranch;
-    if (labelUtils.labelExistsOnPR(context, pr.number, targetLabel)) {
+    if (await labelUtils.labelExistsOnPR(context, pr.number, targetLabel)) {
       await labelUtils.removeLabel(context, pr.number, targetLabel);
     }
   }


### PR DESCRIPTION
Fix a couple of missing `await` calls in the codebase that I spotted via https://lgtm.com/projects/g/electron/trop/?mode=list

```diff
diff --git a/src/utils.ts b/src/utils.ts
index 92e767b..324751b 100644
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export const labelClosedPR = async (
 
   if (change === PRChange.CLOSE) {
     const targetLabel = PRStatus.TARGET + targetBranch;
-    if (labelUtils.labelExistsOnPR(context, pr.number, targetLabel)) {
+    if (await labelUtils.labelExistsOnPR(context, pr.number, targetLabel)) {
       await labelUtils.removeLabel(context, pr.number, targetLabel);
     }
   }
```

This one changed the code to always try to remove a label whether or not it existed. TBH it might be better to just remove this test altogether, since there's no downside (that I know of) to trying to remove a label that doesn't exist, and the upside is one fewer round trips

```
diff --git a/src/index.ts b/src/index.ts
index eaf22fd..5cc41b9 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,7 +491,7 @@ const probotHandler = async (robot: Application) => {
     if (!cmd.startsWith(TROP_COMMAND_PREFIX)) return;
 
     // Allow all users with push access to handle backports.
-    if (!isAuthorizedUser(context, comment.user.login)) {
+    if (!(await isAuthorizedUser(context, comment.user.login))) {
       robot.log(
         `@${comment.user.login} is not authorized to run PR backports - stopping`,
       );
```

If I'm reading this right, authorization testing for trop was previously broken since promises aren't falsy. The specs only test the `true` case, so if this was broken the tests wouldn't be catching it.