### PR TITLE
fix: manual/target label removal

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -564,16 +564,22 @@ export const backportImpl = async (
             ? await getOriginalBackportNumber(context, pr)
             : pr.number;
 
+        if (labelToAdd) {
+          await labelUtils.addLabels(context, originalPRNumber, [labelToAdd]);
+        }
+
         if (labelToRemove) {
           await labelUtils.removeLabel(
             context,
             originalPRNumber,
             labelToRemove,
           );
-        }
-
-        if (labelToAdd) {
-          await labelUtils.addLabels(context, originalPRNumber, [labelToAdd]);
+        } else if (labelToAdd?.startsWith(PRStatus.IN_FLIGHT)) {
+          await labelUtils.removeLabel(
+            context,
+            originalPRNumber,
+            `${PRStatus.NEEDS_MANUAL}${targetBranch}`,
+          );
         }
 
         const labelsToAdd = [BACKPORT_LABEL, `${targetBranch}`];


### PR DESCRIPTION
Fixes issue seen here: https://github.com/electron/electron/pull/29729

A manual backport was triggered for an older PR _from a backport_ which could not be automatically backported from the PR to `main`. Our logic correctly added the in-flight label to the original but didn't account for the `needs-manual` label being present. 