### PR TITLE
ci: update Node.js Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10.15
+      - image: cimg/node:16.13.2
     steps:
       - checkout
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ working
 *.pem
 package-lock.json
 yarn-error.log
+.DS_Store


### PR DESCRIPTION
Previously failing:

> node-fetch@3.1.1: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "10.15.3

See https://github.com/electron/trop/pull/212