### PR TITLE
fix: backports with conflicting semver-labels

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,12 @@ export const NO_BACKPORT_LABEL = 'no-backport';
 
 export const SEMVER_PREFIX = 'semver/';
 
+export const SEMVER_LABELS = {
+  PATCH: 'semver/patch',
+  MINOR: 'semver/minor',
+  MAJOR: 'semver/major',
+};
+
 export const SKIP_CHECK_LABEL =
   process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
 

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -77,7 +77,10 @@ export const updateManualBackport = async (
       // we need to compare the two semver labels and ensure the higher one
       // takes precedence.
       const newPRSemverLabel = labelUtils.getSemverLabel(pr);
-      if (newPRSemverLabel) {
+      if (
+        newPRSemverLabel &&
+        newPRSemverLabel.name !== originalPRSemverLabel.name
+      ) {
         const higherLabel = labelUtils.getHighestSemverLabel(
           originalPRSemverLabel.name,
           newPRSemverLabel.name,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -598,7 +598,7 @@ export const backportImpl = async (
           // we need to compare the two semver labels and ensure the higher one
           // takes precedence.
           const newPRSemverLabel = labelUtils.getSemverLabel(newPr);
-          if (newPRSemverLabel) {
+          if (newPRSemverLabel && newPRSemverLabel.name !== semverLabel.name) {
             const higherLabel = labelUtils.getHighestSemverLabel(
               semverLabel.name,
               newPRSemverLabel.name,

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -23,25 +23,19 @@ export const getSemverLabel = (pr: Octokit.PullsGetResponse) => {
   return pr.labels.find((l: any) => l.name.startsWith(SEMVER_PREFIX));
 };
 
-export const getHighestSemverLabel = (first: string, second: string) => {
-  if ([first, second].every((label) => label.startsWith(SEMVER_PREFIX))) {
+export const getHighestSemverLabel = (...labels: string[]) => {
+  const ranked = [
+    SEMVER_LABELS.PATCH,
+    SEMVER_LABELS.MINOR,
+    SEMVER_LABELS.MAJOR,
+  ];
+
+  const indices = labels.map((label) => ranked.indexOf(label));
+  if (indices.some((index) => index === -1)) {
     throw new Error('Invalid semver labels');
   }
 
-  // Labels are equal, return either.
-  if (first === second) return first;
-  // first is major, second is patch/minor/none.
-  if (first === SEMVER_LABELS.MAJOR) return first;
-  // second is major, first is patch/minor/none.
-  if (second === SEMVER_LABELS.MAJOR) return second;
-  // first is minor, second is patch/none.
-  if (first === SEMVER_LABELS.MINOR) return first;
-  // second is minor, first is patch/none.
-  if (second === SEMVER_LABELS.MINOR) return second;
-  // first is patch, second is none.
-  if (first === SEMVER_LABELS.PATCH) return first;
-  // second is patch, first is none.
-  return second;
+  return ranked[Math.max(...indices)];
 };
 
 export const removeLabel = async (

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -2,6 +2,7 @@ import { Context } from 'probot';
 import { Octokit } from '@octokit/rest';
 import { log } from './log-util';
 import { LogLevel } from '../enums';
+import { SEMVER_LABELS, SEMVER_PREFIX } from '../constants';
 
 export const addLabels = async (
   context: Context,
@@ -16,6 +17,31 @@ export const addLabels = async (
       labels: labelsToAdd,
     }),
   );
+};
+
+export const getSemverLabel = (pr: Octokit.PullsGetResponse) => {
+  return pr.labels.find((l: any) => l.name.startsWith(SEMVER_PREFIX));
+};
+
+export const getHighestSemverLabel = (first: string, second: string) => {
+  if ([first, second].every((label) => label.startsWith(SEMVER_PREFIX))) {
+    throw new Error('Invalid semver labels');
+  }
+
+  // Labels are equal, return either.
+  if (first === second) return first;
+  // first is major, second is patch/minor/none.
+  if (first === SEMVER_LABELS.MAJOR) return first;
+  // second is major, first is patch/minor/none.
+  if (second === SEMVER_LABELS.MAJOR) return second;
+  // first is minor, second is patch/none.
+  if (first === SEMVER_LABELS.MINOR) return first;
+  // second is minor, first is patch/none.
+  if (second === SEMVER_LABELS.MINOR) return second;
+  // first is patch, second is none.
+  if (first === SEMVER_LABELS.PATCH) return first;
+  // second is patch, first is none.
+  return second;
 };
 
 export const removeLabel = async (


### PR DESCRIPTION
Fix an issue where multiple semver labels could incorrectly be applied to a single PR.

See https://github.com/electron/electron/pull/33292.