### PR TITLE
chore: switch from master to main

### DIFF
--- a/docs/manual-backports.md
+++ b/docs/manual-backports.md
@@ -20,7 +20,7 @@ or a full link to the original PR:
 Backport of https://github.com/electron/electron/pull/21813
 ```
 
-If you raise a PR to a branch that isn't `master` or a release branch without including a valid reference as above, `trop` will create a
+If you raise a PR to a branch that isn't `main` or a release branch without including a valid reference as above, `trop` will create a
 "failed" check on that PR to prevent it being merged.
 
 ## Skipping Backport Checks

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,9 +13,9 @@ Welcome! We're glad you want to try out `trop`.
 #### Using `trop`:
 
 **Automatically With Labels**:
-1. Open a bugfix or feature pull request to `master`
+1. Open a bugfix or feature pull request to `main`
 2. Add backport label(s) to the pull request (ex. `target/2-0-x`)
-3. Your pull request is reviewed and you or a co-contributor merges it into `master`
+3. Your pull request is reviewed and you or a co-contributor merges it into `main`
 4. `trop` will automatically open pull requests containing `cherry-pick`s of the code into the backporting branches you specified in your labels (in this case, `2-0-x`).
 5. You or a co-contributor resolves any conflicts and merges in `trop`'s backports
 
@@ -24,8 +24,8 @@ so that you or another contributor and perform the backport manually.  Trop will
 and update the labels appropriately.
 
 **Manual Triggering With Labels**:
-1. Open a bugfix or feature pull request to `master`
-2. Your pull request is reviewed and you or a co-contributor merges it into `master`
+1. Open a bugfix or feature pull request to `main`
+2. Your pull request is reviewed and you or a co-contributor merges it into `main`
 3. After it's been merged, you add backport label(s) to the pull request (ex. `target/2-0-x`)
 4. You create a new comment with the following body: `/trop run backport`
 5. `trop` will begin the backport process for target branches you have specified via labels
@@ -33,8 +33,8 @@ and update the labels appropriately.
 7. You or a co-contributor resolves any conflicts and merges in `trop`'s backports
 
 **Manual Triggering Without Labels**:
-1. Open a bugfix or feature pull request to `master`
-2. Your pull request is reviewed and you or a co-contributor merges it into `master`
+1. Open a bugfix or feature pull request to `main`
+2. Your pull request is reviewed and you or a co-contributor merges it into `main`
 3. You create a new comment with the following body: `/trop run backport-to [BRANCH_NAME]`, where `[BRANCH_NAME]` is replaced with the branch you wish to backport to
 4. `trop` will begin the backport process for target branch you manually specified
 5. `trop` will automatically open pull requests containing `cherry-pick`s of the code into the branch you specified in your comment body

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -443,7 +443,7 @@ export const backportImpl = async (
 
       const pr: Octokit.PullsGetResponse = context.payload.pull_request;
 
-      // Set up empty repo on master.
+      // Set up empty repo on main.
       const { dir } = await initRepo({
         slug,
         accessToken: repoAccessToken,

--- a/src/utils/checks-util.ts
+++ b/src/utils/checks-util.ts
@@ -19,7 +19,7 @@ export async function updateBackportValidityCheck(
       conclusion: statusItems.conclusion as CheckRunStatus,
       completed_at: new Date().toISOString(),
       details_url:
-        'https://github.com/electron/trop/blob/master/docs/manual-backports.md',
+        'https://github.com/electron/trop/blob/main/docs/manual-backports.md',
       output: {
         title: statusItems.title,
         summary: statusItems.summary,


### PR DESCRIPTION
This PR switches `trop` from CircleCI to GitHub Actions as well as updates references to prepare for a switch from `master` to `main`.