### PR TITLE
chore: decrease number of supported branches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ export const CHECK_PREFIX = 'Backportable? - ';
 
 export const BACKPORT_INFORMATION_CHECK = 'Backport Labels Added';
 
-export const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 4;
+export const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 3;
 
 export const BACKPORT_LABEL = 'backport';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,7 @@ const probotHandler = async (robot: Application) => {
               conclusion: CheckRunStatus.FAILURE,
             });
           } else {
-            robot.log(`#${pr.number} is a valid backpot of #${oldPRNumber}`);
+            robot.log(`#${pr.number} is a valid backport of #${oldPRNumber}`);
             await updateBackportValidityCheck(context, checkRun, {
               title: 'Valid Backport',
               summary: `This PR is declared as backporting "#${oldPRNumber}" which is a valid PR that has been merged into ${pr.base.repo.default_branch}`,


### PR DESCRIPTION
This PR bumps the number of supported versions from 5 back to 4 as the [extended release timeline](https://www.electronjs.org/blog/8-week-cadence#2021-plan-for-releases) comes to a close.

NOTE: Please do not merge until after the last 15-x-y and 16-x-y releases have been cut on Tuesday, May 24th