### PR TITLE
Update fs-extra to version 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/ioredis": "^4.14.2",
     "@types/lru-cache": "^5.1.0",
     "config-yml": "^0.10.2",
-    "fs-extra": "^7.0.0",
+    "fs-extra": "^8.0.0",
     "node-fetch": "^2.6.7",
     "probot": "^9.6.6",
     "prom-client": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,12 +2414,12 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-extra@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -2554,6 +2554,11 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.2.0:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps fs-extra to version 8.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>List of files JSFIX failed to analyze.</summary>

* Dockerfile (TypeError) - emessage: Cannot read properties of null (reading 'startsWith').

</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.