### PR TITLE
chore: fix simple-git dep update

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.5",
-    "@types/express": "^4.17.2",
     "@types/fs-extra": "^5.0.1",
     "@types/jest": "^29.0.0",
-    "@types/node": "^10.17.9",
+    "@types/node": "^18.11.8",
     "@types/node-fetch": "^2.5.4",
     "@types/pino-std-serializers": "^4.0.0",
     "@types/sinon": "^5.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,23 +1093,13 @@
     "@types/node" "*"
 
 "@types/express-serve-static-core@^4.17.18":
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz#00acfc1632e729acac4f1530e9e16f6dd1508a1d"
-  integrity sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==
+  version "4.17.32"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz#93dda387f5516af616d8d3f05f2c4c79d81e1b82"
+  integrity sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
-
-"@types/express@^4.17.2":
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
-  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
 
 "@types/express@^4.17.9":
   version "4.17.14"
@@ -1216,10 +1206,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@^10.17.9":
-  version "10.17.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.58.tgz#10682f6016fd866725c36d22ce6bbbd029bf4545"
-  integrity sha512-Dn5RBxLohjdHFj17dVVw3rtrZAeXeWg+LQfvxDIW/fdPkSiuQk7h3frKMYtsQhtIW42wkErDcy9UMVxhGW4O7w==
+"@types/node@^18.11.8":
+  version "18.11.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
This makes #236 compile properly.

* `@types/node` is updated to Node 18 LTS. The latest version of `simple-git` includes `AbortSignal` symbol somewhere in its TypeScript definitions, which was only available starting in Node 15 ([AbortSignal on MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)).
* `@types/express-serve-static-core` had a bug that required a patch version upgrade in `yarn.lock` (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46639#issuecomment-858857876)
* Removed the top-level `@types/express` dependency it was different from the one resolved through Probot.