### PR TITLE
docs: remove outdated example config

### DIFF
--- a/docs/.example.config
+++ b/docs/.example.config
@@ -1,6 +1,0 @@
-watchedProject:
-  name: YOUR_PROJECT_NAME
-
-authorizedUsers:
-  - codebytere
-  - MarshallOfSound

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,10 +6,6 @@ Welcome! We're glad you want to try out `trop`.
 
 `trop` automates backporting PRs to versioned release branches.
 
-#### You Will Need:
-
-1. A `.github/config.yml` file. See [this example](.example.config).
-
 #### Using `trop`:
 
 **Automatically With Labels**:


### PR DESCRIPTION
As far as I can tell, trop no longer uses `.github/config.yml` at all, and instead checks authorized users directly, so this example config is not needed.

https://github.com/electron/trop/blob/f4884ec06b0520ffb14d32bef4c3e8ee3b69688f/src/utils.ts#L252-L263