### PR TITLE
fix: use --keep-cr option for git am

### DIFF
--- a/src/operations/backport-commits.ts
+++ b/src/operations/backport-commits.ts
@@ -77,7 +77,7 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
   for (const patch of options.patches) {
     try {
       await fs.writeFile(patchPath, patch, 'utf8');
-      await git.raw(['am', '-3', patchPath]);
+      await git.raw(['am', '-3', '--keep-cr', patchPath]);
     } catch (error) {
       log(
         'backportCommitsToBranch',


### PR DESCRIPTION
If the file being patched has CRLF line endings, `git am` will fail to apply an otherwise good patch. That's what causes the backport to `24-x-y` on https://github.com/electron/electron/pull/37603 to fail.

This change refs [`script/lib/git.py`](https://github.com/electron/electron/blob/42e7cd9b3f3e16d07f162716b4f1346e32004aec/script/lib/git.py#L59-L62) in `e/e` where the `--keep-cr` option is enabled by default with the usage of `git am` for applying patches there, for this same reason:

```python
# Keep the CR of CRLF in case any patches target files with Windows line
# endings.
args += ['--keep-cr']
```

For reference, here are the logs for the failed backport on that PR:

<details>

```
backportImpl: Fetching squash commit details
backportImpl: Got squash commit details
backportImpl: Checking out target: "target_repo/24-x-y" to temp: "trop/24-x-y-bp-docs-change-msdn-links-to-new-microsoft-docs-1679680976297"
backportCommitsToBranch: Backporting 1 commits to 24-x-y
backportCommitsToBranch: The provided temporary branch name "trop/24-x-y-bp-docs-change-msdn-links-to-new-microsoft-docs-1679680976297" already exists, deleting existing ref before backporting
backportCommitsToBranch: Failed to apply patch to 24-x-y,Error: Applying: docs: change MSDN links to new Microsoft docs
Using index info to reconstruct a base tree...
M	docs/api/browser-window.md
M	docs/api/native-image.md
Patch failed at 0001 docs: change MSDN links to new Microsoft docs
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
error: patch failed: docs/fiddles/menus/customize-menus/index.html:70
error: docs/fiddles/menus/customize-menus/index.html: patch does not apply
error: Did you hand edit your patch?
It does not apply to blobs recorded in its index.
hint: Use 'git am --show-current-patch' to see the failed patch
backportImpl: Cherry picking commits to branch failed
Error: Cherry picking commit(s) to branch failed
    at Queue_1.default.enterQueue.annotations (/app/lib/utils.js:344:19)
removeLabel: Removing target/24-x-y from PR #37603
```

</details>