### PR TITLE
ci: update semantic PR title check workflow

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,7 +1,7 @@
 name: "Check Semantic Commit"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -13,13 +13,13 @@ permissions:
 jobs:
   main:
     permissions:
-      pull-requests: read
-      statuses: write
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@v4
+        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Drops the usage of `pull_request_target`, bumps the action version and pins the SHA.