### PR TITLE
build: revert extended release versions for E22

### DIFF
--- a/src/utils/branch-util.ts
+++ b/src/utils/branch-util.ts
@@ -51,15 +51,9 @@ export async function getSupportedBranches(
     });
 
   const values = Object.values(filtered);
-  const supported = values
+  return values
     .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
     .slice(-NUM_SUPPORTED_VERSIONS);
-  // TODO: We're supporting Electron 22 until Oct. 10, 2023.
-  // Remove this hardcoded value at that time.
-  if (!supported.includes('22-x-y')) {
-    supported.unshift('22-x-y');
-  }
-  return supported;
 }
 
 /**


### PR DESCRIPTION
This PR removes extended support for Electron 22.

Reverts commit 61389182216f72c45ff094a6f92c6d0741c56511.