### PR TITLE
build: run prettier to fix lint

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -118,8 +118,7 @@ describe('trop', () => {
             data: [
               {
                 id: 208045946,
-                url:
-                  'https://api.github.com/repos/octocat/Hello-World/labels/bug',
+                url: 'https://api.github.com/repos/octocat/Hello-World/labels/bug',
                 name: 'bug',
                 description: "Something isn't working",
                 color: 'f29513',
@@ -244,8 +243,9 @@ describe('trop', () => {
 
       await robot.receive(event);
 
-      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
-        .mock.calls[0][2];
+      const updatePayload = (
+        checkUtils.updateBackportInformationCheck as jest.Mock
+      ).mock.calls[0][2];
 
       expect(updatePayload).toMatchObject({
         title: 'Conflicting Backport Information',
@@ -268,8 +268,9 @@ describe('trop', () => {
 
       await robot.receive(event);
 
-      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
-        .mock.calls[0][2];
+      const updatePayload = (
+        checkUtils.updateBackportInformationCheck as jest.Mock
+      ).mock.calls[0][2];
 
       expect(updatePayload).toMatchObject({
         title: 'Backport Information Provided',
@@ -291,8 +292,9 @@ describe('trop', () => {
 
       await robot.receive(event);
 
-      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
-        .mock.calls[0][2];
+      const updatePayload = (
+        checkUtils.updateBackportInformationCheck as jest.Mock
+      ).mock.calls[0][2];
 
       expect(updatePayload).toMatchObject({
         title: 'Backport Information Provided',

--- a/src/index.ts
+++ b/src/index.ts
@@ -540,8 +540,7 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
             await context.octokit.issues.createComment(
               context.repo({
                 issue_number: issue.number,
-                body:
-                  'This PR has not been merged yet, and cannot be backported.',
+                body: 'This PR has not been merged yet, and cannot be backported.',
               }),
             );
             return false;
@@ -560,8 +559,7 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
           ).data as WebHookPR;
           await context.octokit.issues.createComment(
             context.repo({
-              body:
-                'The backport process for this PR has been manually initiated - here we go! :D',
+              body: 'The backport process for this PR has been manually initiated - here we go! :D',
               issue_number: issue.number,
             }),
           );

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -113,14 +113,13 @@ please check out #${pr.number}`;
 
     // TODO(codebytere): Once probot updates to @octokit/rest@16 we can use .paginate to
     // get all the comments properly, for now 100 should do
-    const {
-      data: existingComments,
-    } = await context.octokit.issues.listComments(
-      context.repo({
-        issue_number: oldPRNumber,
-        per_page: 100,
-      }),
-    );
+    const { data: existingComments } =
+      await context.octokit.issues.listComments(
+        context.repo({
+          issue_number: oldPRNumber,
+          per_page: 100,
+        }),
+      );
 
     // We should only comment if there is not a previous existing comment
     const shouldComment = !existingComments.some(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,8 +116,7 @@ const tryBackportAllCommits = async (opts: TryBackportOptions) => {
     await context.octokit.issues.createComment(
       context.repo({
         issue_number: opts.pr.number,
-        body:
-          'This PR has exceeded the automatic backport commit limit \
+        body: 'This PR has exceeded the automatic backport commit limit \
 and must be performed manually.',
       }),
     );
@@ -357,9 +356,8 @@ const checkUserHasWriteAccess = async (
   );
 
   const params = context.repo({ username: user });
-  const {
-    data: userInfo,
-  } = await context.octokit.repos.getCollaboratorPermissionLevel(params);
+  const { data: userInfo } =
+    await context.octokit.repos.getCollaboratorPermissionLevel(params);
 
   // Possible values for the permission key: 'admin', 'write', 'read', 'none'.
   // In order for the user's review to count, they must be at least 'write'.


### PR DESCRIPTION
Not sure what happened with de0120fec24c093d519310624a8bee69d975149a, but the output is not the format that prettier on a clean checkout is expecting. Ran `yarn prettier:format` on a clean checkout to fix it.