### PR TITLE
chore: update manual backport readme and trop comment with `e backport` command

### DIFF
--- a/docs/manual-backports.md
+++ b/docs/manual-backports.md
@@ -1,6 +1,6 @@
 # Manual Backports
 
-When `trop` fails to backport your PR (trust us it tried its best) you need to backport the PR manually. You can do this by cherry-picking the commits in the PR yourself locally and pushing up a new branch.
+When `trop` fails to backport your PR (trust us it tried its best) you need to backport the PR manually. You can do this by cherry-picking the commits in the PR yourself locally and pushing up a new branch or using a [`build-tools` command](#build-tools-backport-command).
 
 When you create PR for a manual backport, the body of the backport PR must contain: 
 
@@ -22,6 +22,10 @@ Backport of https://github.com/electron/electron/pull/21813
 
 If you raise a PR to a branch that isn't `main` or a release branch without including a valid reference as above, `trop` will create a
 "failed" check on that PR to prevent it being merged.
+
+## Build Tools Backport Command
+
+You can use the `e backport <PR>` command to backport PRs. [This command](https://github.com/electron/build-tools?tab=readme-ov-file#e-backport) manually backport PRs by automating the steps above.
 
 ## Skipping Backport Checks
 

--- a/docs/manual-backports.md
+++ b/docs/manual-backports.md
@@ -25,7 +25,7 @@ If you raise a PR to a branch that isn't `main` or a release branch without incl
 
 ## Build Tools Backport Command
 
-You can use the `e backport <PR>` command to backport PRs. [This command](https://github.com/electron/build-tools?tab=readme-ov-file#e-backport) manually backport PRs by automating the steps above.
+You can use the `e backport <PR>` command to backport PRs. [This command](https://github.com/electron/build-tools?tab=readme-ov-file#e-backport-pr) manually backports PRs by automating the steps above.
 
 ## Skipping Backport Checks
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -726,7 +726,7 @@ export const backportImpl = async (
           context.repo({
             issue_number: pr.number,
             body: `I was unable to backport this PR to "${targetBranch}" cleanly;
-   you will need to perform this backport manually.`,
+   you will need to perform this [backport manually](https://github.com/electron/trop/blob/main/docs/manual-backports.md#manual-backports).`,
           }),
         );
 


### PR DESCRIPTION
Problem:
- Trop sometimes fails to automatically backport where there are merge conflicts. Instructions on how to manually backport is not easy to find. 

This PR:
- [x] Update Trop manual backport README with link to build-tools `e backport` updated in https://github.com/electron/build-tools/pull/571 
- [x] Update Trop comment with link to manual backport README 