### PR TITLE
fix: add team_reviewers to requestReviewers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -410,12 +410,12 @@ export const tagBackportReviewers = async ({
   const teamReviewers = [];
 
   if (DEFAULT_BACKPORT_REVIEW_TEAM) {
+    // Optionally request a default review team for backports.
     teamReviewers.push(DEFAULT_BACKPORT_REVIEW_TEAM);
   }
 
   if (user) {
     const hasWrite = await checkUserHasWriteAccess(context, user);
-    // Optionally request a default review team for backports.
     // If the PR author has write access, also request their review.
     if (hasWrite) reviewers.push(user);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -412,8 +412,10 @@ export const tagBackportReviewers = async ({
   if (DEFAULT_BACKPORT_REVIEW_TEAM) {
     // Optionally request a default review team for backports.
     // Use team slug value. i.e electron/wg-releases => wg-releases
-    const slug = DEFAULT_BACKPORT_REVIEW_TEAM.split('/')[1];
-    teamReviewers.push(slug ? slug : DEFAULT_BACKPORT_REVIEW_TEAM);
+    const slug =
+      DEFAULT_BACKPORT_REVIEW_TEAM.split('/')[1] ||
+      DEFAULT_BACKPORT_REVIEW_TEAM;
+    teamReviewers.push(slug);
   }
 
   if (user) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -413,7 +413,7 @@ export const tagBackportReviewers = async ({
     // Optionally request a default review team for backports.
     // Use team slug value. i.e electron/wg-releases => wg-releases
     const slug = DEFAULT_BACKPORT_REVIEW_TEAM.split('/')[1];
-    teamReviewers.push(slug);
+    teamReviewers.push(slug ? slug : DEFAULT_BACKPORT_REVIEW_TEAM);
   }
 
   if (user) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -411,7 +411,9 @@ export const tagBackportReviewers = async ({
 
   if (DEFAULT_BACKPORT_REVIEW_TEAM) {
     // Optionally request a default review team for backports.
-    teamReviewers.push(DEFAULT_BACKPORT_REVIEW_TEAM);
+    // Use team slug value. i.e electron/wg-releases => wg-releases
+    const slug = DEFAULT_BACKPORT_REVIEW_TEAM.split('/')[1];
+    teamReviewers.push(slug);
   }
 
   if (user) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -407,9 +407,10 @@ export const tagBackportReviewers = async ({
   user?: string;
 }) => {
   const reviewers = [];
+  const teamReviewers = [];
 
   if (DEFAULT_BACKPORT_REVIEW_TEAM) {
-    reviewers.push(DEFAULT_BACKPORT_REVIEW_TEAM);
+    teamReviewers.push(DEFAULT_BACKPORT_REVIEW_TEAM);
   }
 
   if (user) {
@@ -419,11 +420,12 @@ export const tagBackportReviewers = async ({
     if (hasWrite) reviewers.push(user);
   }
 
-  if (reviewers.length > 0) {
+  if (Math.max(reviewers.length, teamReviewers.length) > 0) {
     await context.octokit.pulls.requestReviewers(
       context.repo({
         pull_number: targetPrNumber,
         reviewers,
+        team_reviewers: teamReviewers,
       }),
     );
   }


### PR DESCRIPTION
This PR:
- [x] Adds `DEFAULT_BACKPORT_REVIEW_TEAM` to missing team_reviewers param in octokit:[ See API doc](https://octokit.github.io/rest.js/v20#pulls-request-reviewers)
- [x] Should fix bug on why releases team is being tagged for automatic or manual backports