### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,15 @@
-version: 2
-jobs:
-  test:
-    docker:
-      - image: cimg/node:16.13.2
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
-      - run: yarn lint
-      - run: yarn test
+version: 2.1
+
+orbs:
+  node: electronjs/node@2.2.1
+
 workflows:
-  version: 2
   build:
     jobs:
-      - test
+      - node/test:
+          executor: node/linux
+          node-version: "20.12"
+          use-test-steps: true
+          test-steps:
+            - run: yarn lint
+            - run: yarn test


### PR DESCRIPTION
Simplifies the config a little by using `electronjs/node` and bumps the Node.js version. IMO it's better to use `electronjs/node` here instead of pinning to a specific `cimg/node` since I don't know how long those tags receive security updates for, while `electronjs/node` installs Node.js on top of `cimg/base`.