### PR TITLE
fix: restore setting user in git config

### DIFF
--- a/src/operations/init-repo.ts
+++ b/src/operations/init-repo.ts
@@ -65,5 +65,10 @@ export const initRepo = async ({
     await git.clone(cacheDir, '.');
   });
 
+  const config = fs.readFileSync('./config.yml', 'utf8');
+  const { tropEmail, tropName } = parse(config);
+  await git.addConfig('user.email', tropEmail || 'trop@example.com');
+  await git.addConfig('user.name', tropName || 'Trop Bot');
+
   return { dir };
 };


### PR DESCRIPTION
Follow-up to #275 where I gave a bad suggestion to remove this code - turns out it's required for running `git am` even if we're making the actual commit via the GitHub API.

Not sure if `await git.addConfig('commit.gpgsign', 'false');` also needs to be restored, will watch the logs and do another PR if that's necessary.