### PR TITLE
refactor: add try catch to reviewer

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -26,13 +26,10 @@ jest.mock('../src/constants', () => ({
   DEFAULT_BACKPORT_REVIEW_TEAM: 'electron/wg-releases',
 }));
 
-jest.mock('../src/utils', () => {
-  const actualUtils = jest.requireActual('../src/utils');
-  return {
-    ...actualUtils,
-    isSemverMinorPR: jest.fn().mockReturnValue(false),
-  };
-});
+jest.mock('../src/utils', () => ({
+  ...jest.requireActual('../src/utils'),
+  isSemverMinorPR: jest.fn().mockReturnValue(false),
+}));
 
 jest.mock('../src/utils/label-utils', () => ({
   labelExistsOnPR: jest.fn().mockResolvedValue(true),

--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -21,11 +21,6 @@ const backportPRClosedEvent = require('./fixtures/backport_pull_request.closed.j
 const backportPRMergedEvent = require('./fixtures/backport_pull_request.merged.json');
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
 
-jest.mock('../src/constants', () => ({
-  ...jest.requireActual('../src/constants'),
-  DEFAULT_BACKPORT_REVIEW_TEAM: 'electron/wg-releases',
-}));
-
 jest.mock('../src/utils', () => ({
   tagBackportReviewers: jest.fn().mockReturnValue(Promise.resolve()),
   isSemverMinorPR: jest.fn().mockReturnValue(false),
@@ -138,12 +133,11 @@ describe('runner', () => {
       },
     };
 
-    const mockContext = { octokit, repo: jest.fn() };
-
     it('tags reviewers on manual backport creation', async () => {
       const context = {
         ...backportPROpenedEvent,
-        ...mockContext,
+        octokit,
+        repo: jest.fn(),
       };
       await updateManualBackport(context, PRChange.OPEN, 1234);
       expect(tagBackportReviewers).toHaveBeenCalled();
@@ -156,7 +150,8 @@ describe('runner', () => {
     it('does not tag reviewers on merged PRs', async () => {
       const context = {
         ...backportPRMergedEvent,
-        ...mockContext,
+        octokit,
+        repo: jest.fn(),
       };
       await updateManualBackport(context, PRChange.MERGE, 1234);
       expect(tagBackportReviewers).not.toHaveBeenCalled();
@@ -165,7 +160,8 @@ describe('runner', () => {
     it('does not tag reviewers on closed PRs', async () => {
       const context = {
         ...backportPRClosedEvent,
-        ...mockContext,
+        octokit,
+        repo: jest.fn(),
       };
       await updateManualBackport(context, PRChange.CLOSE, 1234);
       expect(tagBackportReviewers).not.toHaveBeenCalled();

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -55,7 +55,7 @@ describe('utils', () => {
       });
     });
 
-    it('logs an error if tagBackportReviewers throws an error', async () => {
+    it('logs an error if requestReviewers throws an error', async () => {
       const error = new Error('Request failed');
       context.octokit.pulls.requestReviewers = jest
         .fn()

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1,0 +1,77 @@
+import * as logUtils from '../src/utils/log-util';
+import { LogLevel } from '../src/enums';
+import { tagBackportReviewers } from '../src/utils';
+
+const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
+
+jest.mock('../src/constants', () => ({
+  ...jest.requireActual('../src/constants'),
+  DEFAULT_BACKPORT_REVIEW_TEAM: 'electron/wg-releases',
+}));
+
+describe('utils', () => {
+  describe('tagBackportReviewers()', () => {
+    const octokit = {
+      pulls: {
+        requestReviewers: jest.fn(),
+      },
+      repos: {
+        getCollaboratorPermissionLevel: jest.fn().mockReturnValue(
+          Promise.resolve({
+            data: {
+              permission: 'admin',
+            },
+          }),
+        ),
+      },
+    };
+
+    const context = {
+      octokit,
+      repo: jest.fn((obj) => obj),
+      ...backportPROpenedEvent,
+    };
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('correctly tags team reviewers when user is undefined', async () => {
+      await tagBackportReviewers({ context, targetPrNumber: 1234 });
+      expect(octokit.pulls.requestReviewers).toHaveBeenCalled();
+      expect(octokit.pulls.requestReviewers).toHaveBeenCalledWith({
+        pull_number: 1234,
+        team_reviewers: ['wg-releases'],
+        reviewers: [],
+      });
+    });
+
+    it('correctly tags team reviewers and reviewers when user is defined', async () => {
+      const user = 'abc';
+      await tagBackportReviewers({ context, targetPrNumber: 1234, user });
+      expect(octokit.pulls.requestReviewers).toHaveBeenCalled();
+      expect(octokit.pulls.requestReviewers).toHaveBeenCalledWith({
+        pull_number: 1234,
+        team_reviewers: ['wg-releases'],
+        reviewers: [user],
+      });
+    });
+
+    it('logs an error if tagBackportReviewers throws an error', async () => {
+      const error = new Error('Request failed');
+      context.octokit.pulls.requestReviewers = jest
+        .fn()
+        .mockRejectedValue(error);
+
+      const logSpy = jest.spyOn(logUtils, 'log');
+      await tagBackportReviewers({ context, targetPrNumber: 1234 });
+
+      expect(octokit.pulls.requestReviewers).toHaveBeenCalled();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'tagBackportReviewers',
+        LogLevel.ERROR,
+        `Failed to request reviewers for PR #1234`,
+        error,
+      );
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -434,8 +434,11 @@ export const tagBackportReviewers = async ({
         }),
       );
     } catch (error) {
-      console.error(
-        `Failed to request reviewers for PR #${targetPrNumber}: ${error}`,
+      log(
+        'tagBackportReviewers',
+        LogLevel.ERROR,
+        `Failed to request reviewers for PR #${targetPrNumber}`,
+        error,
       );
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -435,9 +435,7 @@ export const tagBackportReviewers = async ({
       );
     } catch (error) {
       console.error(
-        `Failed to request reviewers for PR #${targetPrNumber}. Reviewers: ${reviewers.join(
-          ', ',
-        )}, Team Reviewers: ${teamReviewers.join(', ')}. Error: ${error}`,
+        `Failed to request reviewers for PR #${targetPrNumber}: ${error}`,
       );
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -425,13 +425,21 @@ export const tagBackportReviewers = async ({
   }
 
   if (Math.max(reviewers.length, teamReviewers.length) > 0) {
-    await context.octokit.pulls.requestReviewers(
-      context.repo({
-        pull_number: targetPrNumber,
-        reviewers,
-        team_reviewers: teamReviewers,
-      }),
-    );
+    try {
+      await context.octokit.pulls.requestReviewers(
+        context.repo({
+          pull_number: targetPrNumber,
+          reviewers,
+          team_reviewers: teamReviewers,
+        }),
+      );
+    } catch (error) {
+      console.error(
+        `Failed to request reviewers for PR #${targetPrNumber}. Reviewers: ${reviewers.join(
+          ', ',
+        )}, Team Reviewers: ${teamReviewers.join(', ')}. Error: ${error}`,
+      );
+    }
   }
 };
 


### PR DESCRIPTION
This PR: 

- [x] Adds a try catch block so we can log the error and not stop the process if requestReviewer fails 