### PR TITLE
fix: pr label check

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -22,8 +22,9 @@ const backportPRMergedEvent = require('./fixtures/backport_pull_request.merged.j
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
 
 jest.mock('../src/utils', () => ({
-  tagBackportReviewers: jest.fn().mockReturnValue(Promise.resolve()),
+  tagBackportReviewers: jest.fn(),
   isSemverMinorPR: jest.fn().mockReturnValue(false),
+  handleSemverMinorBackportLabel: jest.fn(),
 }));
 
 jest.mock('../src/utils/label-utils', () => ({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,5 +25,7 @@ export const SKIP_CHECK_LABEL =
 export const BACKPORT_REQUESTED_LABEL =
   process.env.BACKPORT_REQUESTED_LABEL || 'backport/requested 🗳';
 
+export const BACKPORT_APPROVED_LABEL = 'backport/approved ✅';
+
 export const DEFAULT_BACKPORT_REVIEW_TEAM =
   process.env.DEFAULT_BACKPORT_REVIEW_TEAM;

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -1,11 +1,7 @@
-import {
-  BACKPORT_LABEL,
-  BACKPORT_REQUESTED_LABEL,
-  SKIP_CHECK_LABEL,
-} from '../constants';
+import { BACKPORT_LABEL, SKIP_CHECK_LABEL } from '../constants';
 import { PRChange, PRStatus, LogLevel } from '../enums';
 import { WebHookPRContext } from '../types';
-import { isSemverMinorPR, tagBackportReviewers } from '../utils';
+import { handleSemverMinorBackportLabel, tagBackportReviewers } from '../utils';
 import * as labelUtils from '../utils/label-utils';
 import { log } from '../utils/log-util';
 
@@ -98,14 +94,12 @@ export const updateManualBackport = async (
       }
     }
 
-    if (await isSemverMinorPR(context, pr)) {
-      log(
-        'updateManualBackport',
-        LogLevel.INFO,
-        `Determined that ${pr.number} is semver-minor`,
-      );
-      newPRLabelsToAdd.push(BACKPORT_REQUESTED_LABEL);
-    }
+    await handleSemverMinorBackportLabel(
+      context,
+      pr,
+      newPRLabelsToAdd,
+      'updateManualBackport',
+    );
 
     // We should only comment if there is not a previous existing comment
     const commentBody = `@${pr.user.login} has manually backported this PR to "${pr.base.ref}", \


### PR DESCRIPTION
This PR:
- [x] fixes #282 
- [x] Add helper function in utils called `handleSemverMinorBackportLabel` that handles correct labels for both automatic and manual backport
- [x] Update and added tests