### PR TITLE
fix: don't update backportable check with queued status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,17 +111,7 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
       const targetBranch = labelToTargetBranch(label, PRStatus.TARGET);
       const runName = `${CHECK_PREFIX}${targetBranch}`;
       let checkRun = checkRuns.find((run) => run.name === runName);
-      if (checkRun) {
-        if (checkRun.conclusion !== 'neutral') continue;
-
-        await context.octokit.checks.update(
-          context.repo({
-            name: checkRun.name,
-            check_run_id: checkRun.id,
-            status: 'queued' as 'queued',
-          }),
-        );
-      } else {
+      if (!checkRun) {
         const response = await context.octokit.checks.create(
           context.repo({
             name: runName,


### PR DESCRIPTION
When a PR is labeled with multiple X labels at the same time, trop ends up getting X events (one for each label) but then looks at all the labels on the PR (which sees the final state with Y `target/*` labels) and kicks off checks for each of them. [The duplicate runs get ignored](https://github.com/electron/trop/blob/48fa8b4232ce8c29836e80c7e4e0c64251566752/src/Queue.ts#L24) by `enterQueue`, but currently the status of the check can be overwritten by one of these duplicate runs due to race conditions.

The juice isn't worth the squeeze on trying to get `octokit.checks.update` calls working robustly if the check already exists (without risking overwriting) so just remove it all together.