### PR TITLE
chore: add some logs for debugging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,13 @@ import {
 } from './utils/label-utils';
 import { CHECK_PREFIX, NO_BACKPORT_LABEL, SKIP_CHECK_LABEL } from './constants';
 import { getEnvVar } from './utils/env-util';
-import { PRChange, PRStatus, BackportPurpose, CheckRunStatus } from './enums';
+import {
+  PRChange,
+  PRStatus,
+  BackportPurpose,
+  CheckRunStatus,
+  LogLevel,
+} from './enums';
 import { Label } from '@octokit/webhooks-types';
 import {
   backportToLabel,
@@ -27,6 +33,7 @@ import {
   updateBackportInformationCheck,
   updateBackportValidityCheck,
 } from './utils/checks-util';
+import { log } from './utils/log-util';
 import { register } from './utils/prom';
 import {
   SimpleWebHookRepoContext,
@@ -113,6 +120,12 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
       let checkRun = checkRuns.find((run) => run.name === runName);
       if (checkRun) {
         if (checkRun.conclusion !== 'neutral') continue;
+
+        log(
+          'runCheck',
+          LogLevel.INFO,
+          `Updating check run ID ${checkRun.id} with status 'queued'`,
+        );
 
         await context.octokit.checks.update(
           context.repo({

--- a/src/operations/backport-to-location.ts
+++ b/src/operations/backport-to-location.ts
@@ -16,6 +16,12 @@ const createOrUpdateCheckRun = async (
 
   if (check) {
     if (check.conclusion === 'neutral') {
+      log(
+        'createOrUpdateCheckRun',
+        LogLevel.INFO,
+        `Updating check run ID ${check.id} with status 'queued'`,
+      );
+
       await context.octokit.checks.update(
         context.repo({
           name: check.name,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -486,6 +486,11 @@ export const backportImpl = async (
     `backport-${pr.head.sha}-${targetBranch}-${purpose}`,
     async () => {
       log('backportImpl', LogLevel.INFO, `Executing ${bp} for "${slug}"`);
+      log(
+        'backportImpl',
+        LogLevel.INFO,
+        `Updating check run ID ${checkRun.id} with status 'in_progress'`,
+      );
       await context.octokit.checks.update(
         context.repo({
           check_run_id: checkRun.id,
@@ -676,6 +681,12 @@ export const backportImpl = async (
 
         log('backportImpl', LogLevel.INFO, 'Backport process complete');
       }
+
+      log(
+        'backportImpl',
+        LogLevel.INFO,
+        `Updating check run ID ${checkRun.id} with conclusion 'success'`,
+      );
 
       await context.octokit.checks.update(
         context.repo({


### PR DESCRIPTION
Trying to confirm what's causing backportable checks to get stuck in `queued` state.