### PR TITLE
chore: reset check started_at time when running backportable check

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -496,6 +496,7 @@ export const backportImpl = async (
         context.repo({
           check_run_id: checkRun.id,
           name: checkRun.name,
+          started_at: new Date().toISOString(),
           status: 'in_progress' as 'in_progress',
         }),
       );


### PR DESCRIPTION
Currently the `completed_at` time gets set on each successful check but the `started_at` time reflects when the check was first created. Since checks get re-run each time a PR is modified (edited, labels touched, etc), but the same GitHub check run is reused, this can lead to increasingly long "completed in X" times which are confusing and misleading.