### PR TITLE
fix: prevent accidental branch backport duplication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -543,13 +543,14 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
         name: 'backport to branch',
         command: /^run backport-to (([^,]*)(, ?([^,]*))*)/,
         execute: async (targetBranches: string) => {
-          const branches = targetBranches.split(',').map((b) => b.trim());
+          const branches = new Set(
+            targetBranches.split(',').map((b) => b.trim()),
+          );
           for (const branch of branches) {
             robot.log(
               `Initiating backport to \`${branch}\` from 'backport-to' comment`,
             );
 
-            if (!branch.trim()) continue;
             const pr = (
               await context.octokit.pulls.get(
                 context.repo({ pull_number: issue.number }),


### PR DESCRIPTION
Fixes an issue where a trop PR comment like:

```
\trop run backport-to 32-x-y,32-x-y,30-x-y
```

would incorrectly produce two PRs to 32.