### PR TITLE
build: pin to heroku-22 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,5 +20,6 @@
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "stack": "heroku-22"
 }


### PR DESCRIPTION
[Heroku stopped including Git at runtime](https://devcenter.heroku.com/articles/heroku-24-stack) with `heroku-24`, which is kind of a problem for trop since it uses Git at runtime. 😄 This should buy us some time to get a more proper fix in place.