### PR TITLE
fix: remove needs-manual label from original PR

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ export const labelClosedPR = async (
 
     if (change === PRChange.MERGE) {
       const mergedLabel = PRStatus.MERGED + targetBranch;
-      const needsManualLabel = PRStatus.IN_FLIGHT + targetBranch;
+      const needsManualLabel = PRStatus.NEEDS_MANUAL + targetBranch;
 
       // Add merged label to the original PR.
       await labelUtils.addLabels(context, prNumber, [mergedLabel]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,26 +59,30 @@ export const labelClosedPR = async (
     `Labeling original PRs for PR at #${pr.number}`,
   );
 
+  const targetLabel = PRStatus.TARGET + targetBranch;
+
   if (change === PRChange.CLOSE) {
-    const targetLabel = PRStatus.TARGET + targetBranch;
     await labelUtils.removeLabel(context, pr.number, targetLabel);
   }
 
   const backportNumbers = getPRNumbersFromPRBody(pr);
   for (const prNumber of backportNumbers) {
-    const labelToRemove = PRStatus.IN_FLIGHT + targetBranch;
+    const inFlightLabel = PRStatus.IN_FLIGHT + targetBranch;
+    await labelUtils.removeLabel(context, prNumber, inFlightLabel);
 
-    // Add merged label to the original PR. If this is an intermediary PR,
-    // remove target labels from the current PR.
     if (change === PRChange.MERGE) {
       const mergedLabel = PRStatus.MERGED + targetBranch;
-      const targetLabel = PRStatus.TARGET + targetBranch;
+      const needsManualLabel = PRStatus.IN_FLIGHT + targetBranch;
 
+      // Add merged label to the original PR.
       await labelUtils.addLabels(context, prNumber, [mergedLabel]);
+
+      // Remove the needs-manual-backport label from the original PR.
+      await labelUtils.removeLabel(context, prNumber, needsManualLabel);
+
+      // Remove the target label from the intermediate PR.
       await labelUtils.removeLabel(context, pr.number, targetLabel);
     }
-
-    await labelUtils.removeLabel(context, prNumber, labelToRemove);
   }
 };
 


### PR DESCRIPTION
Closes https://github.com/electron/trop/issues/297.

Ensures that when a backport PR is opened manually, and then target labels are put on that, that the resultant bookkeeping is performed correctly.

1. PR 123 is opened and set to target branches x, y, and z 
2. PR 123 is reviewed and merged
3. Trop opens a backport to z, but can't backport to x and y
4. A maintainer opens a manual backport to y and adds a target to x, which shows it will be clean
5. When the manual backport to y is merged, trop opens a backport from y to x
6. When the auto-backport to x is merged, the original PR 123 should have its label updated to reflect that and the target label should be removed from the PR to y.