### PR TITLE
fix: support non-utf8 files in backports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.0.0",
-    "@types/node": "^18.11.8",
+    "@types/node": "^20.11.8",
     "@types/node-fetch": "^2.5.4",
     "@types/pino-std-serializers": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
@@ -52,7 +52,7 @@
     "{src,spec}/**/*.ts": "prettier --write **/*.ts"
   },
   "engines": {
-    "node": ">= 7.7.0",
+    "node": ">= 20.7.0",
     "npm": ">= 4.0.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,10 +1312,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@^18.11.8":
-  version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+"@types/node@^20.11.8":
+  version "20.16.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.8.tgz#36f5c22e2ac6b61f3728f756d27e759246f0e98a"
+  integrity sha512-sbo5JmfbZNkyDv+2HCccr9Y9ZkKJBMTru7UdAsCojMGjKNjdaOV73bqEW242QrHEZL8R4LbHMrW+FHB5lZ5/bw==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -5598,6 +5600,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 universal-github-app-jwt@^1.0.1:
   version "1.1.1"


### PR DESCRIPTION
You have to make blobs and attach them via `sha` reference if the contents is not a utf8 string.

Fixes #310 