### PR TITLE
chore: improve typings and test mocks

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -22,7 +22,7 @@ const backportPRMergedEvent = require('./fixtures/backport_pull_request.merged.j
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
 
 jest.mock('../src/utils', () => ({
-  tagBackportReviewers: jest.fn().mockReturnValue(Promise.resolve()),
+  tagBackportReviewers: jest.fn().mockResolvedValue(undefined),
   isSemverMinorPR: jest.fn().mockReturnValue(false),
 }));
 
@@ -125,11 +125,11 @@ describe('runner', () => {
   describe('updateManualBackport()', () => {
     const octokit = {
       pulls: {
-        get: jest.fn().mockReturnValue(Promise.resolve({})),
+        get: jest.fn().mockResolvedValue({}),
       },
       issues: {
-        createComment: jest.fn().mockReturnValue(Promise.resolve({})),
-        listComments: jest.fn().mockReturnValue(Promise.resolve({ data: [] })),
+        createComment: jest.fn().mockResolvedValue({}),
+        listComments: jest.fn().mockResolvedValue({ data: [] }),
       },
     };
 

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -16,13 +16,11 @@ describe('utils', () => {
         requestReviewers: jest.fn(),
       },
       repos: {
-        getCollaboratorPermissionLevel: jest.fn().mockReturnValue(
-          Promise.resolve({
-            data: {
-              permission: 'admin',
-            },
-          }),
-        ),
+        getCollaboratorPermissionLevel: jest.fn().mockResolvedValue({
+          data: {
+            permission: 'admin',
+          },
+        }),
       },
     };
 

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -3,7 +3,7 @@ import { log } from './utils/log-util';
 import { LogLevel } from './enums';
 
 export type Executor = () => Promise<void>;
-export type ErrorExecutor = (err: any) => Promise<void>;
+export type ErrorExecutor = (err: unknown) => Promise<void>;
 
 const DEFAULT_MAX_ACTIVE = 5;
 
@@ -36,7 +36,7 @@ export class ExecutionQueue extends EventEmitter {
     this.active += 1;
     fns[1]()
       .then(() => this.runNext(fns[0]))
-      .catch((err: any) => {
+      .catch((err: unknown) => {
         if (!process.env.SPEC_RUNNING) {
           console.error(err);
         }

--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -27,8 +27,8 @@ export const updateManualBackport = async (
   const newPRLabelsToAdd = [pr.base.ref];
 
   // Changed labels on the original PR.
-  let labelToAdd;
-  let labelToRemove;
+  let labelToAdd: string | undefined;
+  let labelToRemove: string;
 
   log(
     'updateManualBackport',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -721,7 +721,7 @@ export const backportImpl = async (
       await fs.remove(createdDir);
     },
     async () => {
-      let annotations: any[] | null = null;
+      let annotations: unknown[] | null = null;
       let diff;
       let rawDiff;
       if (createdDir) {
@@ -751,7 +751,8 @@ export const backportImpl = async (
               message: 'Patch Conflict',
               raw_details: hunk.lines
                 .filter(
-                  (_: any, i: number) => i >= startOffset && i <= finalOffset,
+                  (_: unknown, i: number) =>
+                    i >= startOffset && i <= finalOffset,
                 )
                 .join('\n'),
             });

--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -23,7 +23,7 @@ export const addLabels = async (
 };
 
 export const getSemverLabel = (pr: Pick<WebHookPR, 'labels'>) => {
-  return pr.labels.find((l: any) => l.name.startsWith(SEMVER_PREFIX));
+  return pr.labels.find((l) => l.name.startsWith(SEMVER_PREFIX));
 };
 
 export const getHighestSemverLabel = (...labels: string[]) => {

--- a/src/utils/log-util.ts
+++ b/src/utils/log-util.ts
@@ -10,7 +10,7 @@ import { LogLevel } from '../enums';
 export const log = (
   functionName: string,
   logLevel: LogLevel,
-  ...message: any[]
+  ...message: unknown[]
 ) => {
   const output = `${functionName}: ${message}`;
 


### PR DESCRIPTION
Just some cleanup of the typings in this codebase.

* Use `jest.mocked` for better typing
* `mockReturnValue(Promise.resolve(...))` -> `mockResolvedValue(...)`
* Improve typing and remove most `as any` and `: any` types