### PR TITLE
feat: enforce backport approval with checks

### DIFF
--- a/spec/fixtures/backport_pull_request.labeled.json
+++ b/spec/fixtures/backport_pull_request.labeled.json
@@ -1,0 +1,43 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "labeled",
+    "number": 7,
+    "pull_request": {
+      "number": 7,
+      "url": "my_cool_url",
+      "title": "CHANGE README",
+      "merged": true,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "Backport of #12345",
+      "labels": [{
+        "name": "todo",
+        "color": "8cb728"
+      }],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "main",
+        "repo": {
+          "default_branch": "main"
+        }
+      }
+    },
+    "label": {
+      "name": "todo",
+      "color": "8cb728"
+    },
+    "repository": {
+      "name": "probot-test",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/spec/fixtures/backport_pull_request.unlabeled.json
+++ b/spec/fixtures/backport_pull_request.unlabeled.json
@@ -1,0 +1,43 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "unlabeled",
+    "number": 7,
+    "pull_request": {
+      "number": 7,
+      "url": "my_cool_url",
+      "title": "CHANGE README",
+      "merged": true,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "Backport of #12345",
+      "labels": [{
+        "name": "todo",
+        "color": "8cb728"
+      }],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "main",
+        "repo": {
+          "default_branch": "main"
+        }
+      }
+    },
+    "label": {
+      "name": "todo",
+      "color": "8cb728"
+    },
+    "repository": {
+      "name": "probot-test",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export const CHECK_PREFIX = 'Backportable? - ';
 
+export const BACKPORT_APPROVAL_CHECK = 'Backport Approval Enforcement';
+
 export const BACKPORT_INFORMATION_CHECK = 'Backport Labels Added';
 
 export const NUM_SUPPORTED_VERSIONS = parseInt(
@@ -21,6 +23,9 @@ export const SEMVER_LABELS = {
 
 export const SKIP_CHECK_LABEL =
   process.env.SKIP_CHECK_LABEL || 'backport-check-skip';
+
+export const BACKPORT_APPROVED_LABEL =
+  process.env.BACKPORT_APPROVED_LABEL || 'backport/approved ✅';
 
 export const BACKPORT_REQUESTED_LABEL =
   process.env.BACKPORT_REQUESTED_LABEL || 'backport/requested 🗳';

--- a/src/utils/checks-util.ts
+++ b/src/utils/checks-util.ts
@@ -1,5 +1,9 @@
 import { CheckRunStatus, LogLevel } from '../enums';
-import { BACKPORT_INFORMATION_CHECK, CHECK_PREFIX } from '../constants';
+import {
+  BACKPORT_APPROVAL_CHECK,
+  BACKPORT_INFORMATION_CHECK,
+  CHECK_PREFIX,
+} from '../constants';
 import {
   SimpleWebHookRepoContext,
   WebHookPR,
@@ -89,6 +93,63 @@ export async function queueBackportInformationCheck(context: WebHookPRContext) {
         title: 'Needs Backport Information',
         summary:
           'This PR requires backport information. It should have a "no-backport" or a "target/<branch>" label.',
+      },
+    }),
+  );
+}
+
+export async function getBackportApprovalCheck(context: WebHookPRContext) {
+  const pr = context.payload.pull_request;
+  const allChecks = await context.octokit.checks.listForRef(
+    context.repo({
+      ref: pr.head.sha,
+      per_page: 100,
+    }),
+  );
+
+  const backportCheck = allChecks.data.check_runs.filter((run) =>
+    run.name.startsWith(BACKPORT_APPROVAL_CHECK),
+  );
+
+  return backportCheck.length > 0 ? backportCheck[0] : null;
+}
+
+export async function updateBackportApprovalCheck(
+  context: WebHookPRContext,
+  backportCheck: BackportCheck,
+  statusItems: {
+    conclusion: CheckRunStatus;
+    title: string;
+    summary: string;
+  },
+) {
+  await context.octokit.checks.update(
+    context.repo({
+      check_run_id: backportCheck.id,
+      name: backportCheck.name,
+      conclusion: statusItems.conclusion as CheckRunStatus,
+      completed_at: new Date().toISOString(),
+      details_url: 'https://github.com/electron/trop',
+      output: {
+        title: statusItems.title,
+        summary: statusItems.summary,
+      },
+    }),
+  );
+}
+
+export async function queueBackportApprovalCheck(context: WebHookPRContext) {
+  const pr = context.payload.pull_request;
+
+  await context.octokit.checks.create(
+    context.repo({
+      name: BACKPORT_APPROVAL_CHECK,
+      head_sha: pr.head.sha,
+      status: 'queued',
+      details_url: 'https://github.com/electron/trop',
+      output: {
+        title: 'Needs Backport Approval',
+        summary: 'This PR requires backport approval.',
       },
     }),
   );


### PR DESCRIPTION
There's currently nothing blocking PRs with `backport/requested 🗳` from being merged before they've been formally approved. This adds a check which can be set as a required check for merging on `e/e`, same as how trop's "Valid Backport" check is a required check.

The check is dead simple, it's marked as queued when the `backport/requested 🗳` label is present (so that it can block merging), otherwise it's marked as success (if no `backport/*` labels are present or `backport/approved ✅` is present).