### PR TITLE
fix: move backport approval enforcement to correct code path

### DIFF
--- a/spec/fixtures/pull_request.labeled.json
+++ b/spec/fixtures/pull_request.labeled.json
@@ -1,0 +1,40 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "labeled",
+    "number": 7,
+    "pull_request": {
+      "url": "my_cool_url",
+      "number": 7,
+      "title": "CHANGE README",
+      "merged": true,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "New cool stuff",
+      "labels": [{
+        "name": "todo",
+        "color": "8cb728"
+      }],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "main",
+        "repo": {
+          "default_branch": "main"
+        }
+      }
+    },
+    "label": {
+      "name": "todo",
+      "color": "8cb728"
+    },
+    "repository": {
+      "name": "probot-test",
+      "owner": {
+        "login": "codebytere"
+      }
+    }
+  }
+}

--- a/spec/fixtures/pull_request.unlabeled.json
+++ b/spec/fixtures/pull_request.unlabeled.json
@@ -1,0 +1,40 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "unlabeled",
+    "number": 7,
+    "pull_request": {
+      "url": "my_cool_url",
+      "number": 7,
+      "title": "CHANGE README",
+      "merged": true,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "New cool stuff",
+      "labels": [{
+        "name": "todo",
+        "color": "8cb728"
+      }],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "main",
+        "repo": {
+          "default_branch": "main"
+        }
+      }
+    },
+    "label": {
+      "name": "todo",
+      "color": "8cb728"
+    },
+    "repository": {
+      "name": "probot-test",
+      "owner": {
+        "login": "codebytere"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #336 with a more correct implementation not that test fixtures are updated. 😅 Discussed with @jkleinsc that we can add the required check on `e/e` on only release branches, so that's what the fixed implementation does.