### PR TITLE
feat: avoid `.patches` shear in Electron

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -7,6 +7,7 @@ import simpleGit from 'simple-git';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PRChange } from '../src/enums';
+import { backportCommitsToBranch } from '../src/operations/backport-commits';
 import { initRepo } from '../src/operations/init-repo';
 import { setupRemotes } from '../src/operations/setup-remotes';
 import { updateManualBackport } from '../src/operations/update-manual-backport';
@@ -22,6 +23,36 @@ const saveDir = (o: { dir: string }) => {
 const backportPRClosedEvent = require('./fixtures/backport_pull_request.closed.json');
 const backportPRMergedEvent = require('./fixtures/backport_pull_request.merged.json');
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
+
+const runGit = (cwd: string, args: string[]) => {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr || result.stdout || `git ${args.join(' ')} failed`,
+    );
+  }
+
+  return result.stdout.trimEnd();
+};
+
+const initTestGitRepo = (dir: string) => {
+  runGit(dir, ['init']);
+  runGit(dir, ['checkout', '-b', 'main']);
+  runGit(dir, ['config', 'user.name', 'Trop Test']);
+  runGit(dir, ['config', 'user.email', 'trop@example.com']);
+};
+
+const writeRepoFile = async (
+  repoDir: string,
+  filePath: string,
+  contents: string,
+) => {
+  const fullPath = path.join(repoDir, filePath);
+  await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.promises.writeFile(fullPath, contents);
+};
+
+const buildPatchList = (...entries: string[]) => entries.join('\n');
 
 vi.mock('../src/utils', () => ({
   tagBackportReviewers: vi.fn().mockResolvedValue(undefined),
@@ -120,6 +151,238 @@ describe('runner', () => {
           ).toBeTruthy();
         }
       }
+    });
+  });
+
+  describe('backportCommitsToBranch()', { timeout: 30_000 }, () => {
+    let createdDirs: string[] = [];
+
+    const makeTempDir = async (prefix: string) => {
+      const dir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), prefix));
+      createdDirs.push(dir);
+      return dir;
+    };
+
+    afterEach(async () => {
+      await Promise.all(
+        createdDirs.map((d) =>
+          fs.promises.rm(d, { force: true, recursive: true }),
+        ),
+      );
+      createdDirs = [];
+    });
+
+    // Build two repos with identical initial files, apply changes to the
+    // source, format-patch, publish, clone, and run the backport.
+    // Returns the work directory for assertions.
+    const setupAndBackport = async (opts: {
+      initial: Record<string, string>;
+      changes: Record<string, string>;
+    }): Promise<string> => {
+      const remoteDir = await makeTempDir('trop-remote-');
+      const targetDir = await makeTempDir('trop-target-');
+      const sourceDir = await makeTempDir('trop-source-');
+      const workDir = await makeTempDir('trop-work-');
+
+      runGit(remoteDir, ['init', '--bare']);
+
+      for (const dir of [targetDir, sourceDir]) {
+        initTestGitRepo(dir);
+        for (const [file, content] of Object.entries(opts.initial)) {
+          await writeRepoFile(dir, file, content);
+        }
+        runGit(dir, ['add', '.']);
+        runGit(dir, ['commit', '-m', 'initial']);
+      }
+      runGit(targetDir, ['branch', '42-x-y']);
+
+      for (const [file, content] of Object.entries(opts.changes)) {
+        await writeRepoFile(sourceDir, file, content);
+      }
+      runGit(sourceDir, ['add', ...Object.keys(opts.changes)]);
+      runGit(sourceDir, ['commit', '-m', 'change']);
+      const patch = runGit(sourceDir, [
+        'format-patch',
+        '-1',
+        '--stdout',
+        'HEAD',
+      ]);
+
+      runGit(targetDir, ['remote', 'add', 'origin', remoteDir]);
+      runGit(targetDir, ['push', 'origin', 'main', '42-x-y']);
+      runGit(remoteDir, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+      runGit(workDir, ['clone', remoteDir, '.']);
+      runGit(workDir, ['config', 'user.name', 'Trop Test']);
+      runGit(workDir, ['config', 'user.email', 'trop@example.com']);
+      runGit(workDir, ['remote', 'add', 'target_repo', remoteDir]);
+      runGit(workDir, ['fetch', 'target_repo']);
+
+      const result = await backportCommitsToBranch({
+        context: {} as never,
+        dir: workDir,
+        github: {} as never,
+        patches: [patch],
+        shouldPush: false,
+        slug: 'electron/trop',
+        targetBranch: '42-x-y',
+        targetRemote: 'target_repo',
+        tempBranch: 'backport-to-42-x-y',
+      });
+      expect(result).toEqual({ dir: workDir });
+
+      return workDir;
+    };
+
+    const patchFiles = (
+      dir: string,
+      entries: string[],
+    ): Record<string, string> =>
+      Object.fromEntries(
+        entries.map((e) => [dir ? `${dir}/${e}` : e, `${e}\n`]),
+      );
+
+    const readFile = (workDir: string, file: string) =>
+      fs.promises.readFile(path.join(workDir, file), 'utf8');
+
+    const sharedEntries = ['shared1.patch', 'shared2.patch', 'shared3.patch'];
+    const sharedPatches = buildPatchList(...sharedEntries);
+    const shearedSourcePatches = buildPatchList(
+      ...sharedEntries,
+      'no-backport.patch',
+      'backport.patch',
+    );
+    const expectedShearedPatches = buildPatchList(
+      ...sharedEntries,
+      'backport.patch',
+    );
+    const patchBackportContents = 'patch backport\n';
+
+    it('removes sheared entries from .patches', async () => {
+      const workDir = await setupAndBackport({
+        initial: {
+          '.patches': sharedPatches,
+          ...patchFiles('', sharedEntries),
+        },
+        changes: {
+          '.patches': shearedSourcePatches,
+          'backport.patch': patchBackportContents,
+        },
+      });
+      expect(await readFile(workDir, '.patches')).toBe(expectedShearedPatches);
+      expect(await readFile(workDir, 'backport.patch')).toBe(
+        patchBackportContents,
+      );
+      expect(fs.existsSync(path.join(workDir, 'no-backport.patch'))).toBe(
+        false,
+      );
+    });
+
+    it('handles multiple changed .patches directories', async () => {
+      const crEntries = ['shared1.patch', 'shared2.patch', 'shared3.patch'];
+      const v8Entries = ['alpha.patch', 'beta.patch', 'gamma.patch'];
+
+      const workDir = await setupAndBackport({
+        initial: {
+          'electron/patches/chromium/.patches': buildPatchList(...crEntries),
+          ...patchFiles('electron/patches/chromium', crEntries),
+          'electron/patches/v8/.patches': buildPatchList(...v8Entries),
+          ...patchFiles('electron/patches/v8', v8Entries),
+        },
+        changes: {
+          'electron/patches/chromium/.patches': buildPatchList(
+            ...crEntries,
+            'no-backport.patch',
+            'backport.patch',
+          ),
+          'electron/patches/chromium/backport.patch':
+            'chromium patch backport\n',
+          'electron/patches/v8/.patches': buildPatchList(
+            ...v8Entries,
+            'not-for-backport.patch',
+            'v8-backport.patch',
+          ),
+          'electron/patches/v8/v8-backport.patch': 'v8 patch backport\n',
+        },
+      });
+      expect(
+        await readFile(workDir, 'electron/patches/chromium/.patches'),
+      ).toBe(buildPatchList(...crEntries, 'backport.patch'));
+      expect(await readFile(workDir, 'electron/patches/v8/.patches')).toBe(
+        buildPatchList(...v8Entries, 'v8-backport.patch'),
+      );
+      expect(
+        await readFile(workDir, 'electron/patches/chromium/backport.patch'),
+      ).toBe('chromium patch backport\n');
+      expect(
+        await readFile(workDir, 'electron/patches/v8/v8-backport.patch'),
+      ).toBe('v8 patch backport\n');
+      expect(
+        fs.existsSync(
+          path.join(workDir, 'electron/patches/chromium/no-backport.patch'),
+        ),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(workDir, 'electron/patches/v8/not-for-backport.patch'),
+        ),
+      ).toBe(false);
+    });
+
+    it('preserves .patches-only additions for existing patch files', async () => {
+      const entries = ['shared1.patch', 'shared2.patch'];
+      const expected = buildPatchList(...entries, 'already-present.patch');
+
+      const workDir = await setupAndBackport({
+        initial: {
+          '.patches': buildPatchList(...entries),
+          ...patchFiles('', entries),
+          'already-present.patch': 'already here\n',
+        },
+        changes: { '.patches': expected },
+      });
+      expect(await readFile(workDir, '.patches')).toBe(expected);
+    });
+
+    it('keeps .patches empty when the backported commit removes the last entry', async () => {
+      const workDir = await setupAndBackport({
+        initial: {
+          '.patches': 'obsolete.patch\n',
+          'obsolete.patch': 'obsolete\n',
+        },
+        changes: { '.patches': '' },
+      });
+      expect(await readFile(workDir, '.patches')).toBe('');
+    });
+
+    it('applies correct .patches when source and target are in sync (no shear)', async () => {
+      const entries = ['shared1.patch', 'shared2.patch'];
+      const updated = buildPatchList(...entries, 'new-backport.patch');
+
+      const workDir = await setupAndBackport({
+        initial: {
+          '.patches': buildPatchList(...entries),
+          ...patchFiles('', entries),
+        },
+        changes: { '.patches': updated, 'new-backport.patch': 'new patch\n' },
+      });
+      expect(await readFile(workDir, '.patches')).toBe(updated);
+      expect(await readFile(workDir, 'new-backport.patch')).toBe('new patch\n');
+    });
+
+    it('handles .patches files with trailing newlines correctly', async () => {
+      const workDir = await setupAndBackport({
+        initial: {
+          '.patches': `${sharedPatches}\n`,
+          ...patchFiles('', sharedEntries),
+        },
+        changes: {
+          '.patches': `${shearedSourcePatches}\n`,
+          'backport.patch': patchBackportContents,
+        },
+      });
+      expect(await readFile(workDir, '.patches')).toBe(
+        `${expectedShearedPatches}\n`,
+      );
     });
   });
 

--- a/src/extensions/electron-patches.ts
+++ b/src/extensions/electron-patches.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { SimpleGit } from 'simple-git';
+import { log } from '../utils/log-util';
+import { LogLevel } from '../enums';
+import { BackportExtension } from './types';
+
+// patch content --> array of .patches files that the patch changed
+const getChangedPatchesFiles = (patchContents: string): string[] => {
+  const regex = /^diff --git a\/(.+) b\/(.+)$/gm; // diff --git a/src/foo.ts b/src/foo.ts
+  return [...patchContents.matchAll(regex)]
+    .map(([line, , file]) => file)
+    .filter((file) => path.posix.basename(file) === '.patches')
+    .filter((file, idx, arr) => arr.indexOf(file) === idx); // no dupes
+};
+
+// Handles a special case for Electron `.patches` files: `git am` can pull
+// in extra context lines. But this breaks us because those extra lines
+// are for .patch files that don't exist in the target branch.
+// This function removes those lines.
+const applyPatchesChanges = async (
+  git: SimpleGit,
+  repoDir: string,
+  patchContents: string,
+): Promise<void> => {
+  const crlf = '\r\n';
+  const lf = '\n';
+  let shouldAmend = false;
+
+  for (const patchesPath of getChangedPatchesFiles(patchContents)) {
+    const patchDir = path.posix.dirname(patchesPath);
+    const absPath = path.resolve(repoDir, patchesPath);
+    const current = fs.existsSync(absPath)
+      ? await fs.promises.readFile(absPath, 'utf8')
+      : '';
+
+    const isPatchFile = (f: string): boolean =>
+      !f.startsWith('#') && f.endsWith('.patch');
+    const newline = current.includes(crlf) ? crlf : lf;
+    const newContent = current
+      .split(/\r?\n/)
+      .filter((line) => {
+        const trimmed = line.trim();
+        return (
+          !isPatchFile(trimmed) ||
+          fs.existsSync(path.resolve(repoDir, patchDir, trimmed))
+        );
+      })
+      .join(newline);
+
+    if (newContent === current) continue;
+
+    log(
+      'backportCommitsToBranch',
+      LogLevel.INFO,
+      `Applying .patches changes to ${patchesPath}`,
+    );
+
+    await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.promises.writeFile(absPath, newContent, 'utf8');
+    await git.add(patchesPath);
+    shouldAmend = true;
+  }
+
+  if (shouldAmend) await git.raw(['commit', '--amend', '--no-edit']);
+};
+
+export const electronPatchesExtension: BackportExtension = {
+  name: 'electron-patches',
+
+  async afterApply({ git, dir, patch }) {
+    await applyPatchesChanges(git, dir, patch);
+  },
+};

--- a/src/extensions/electron-patches.ts
+++ b/src/extensions/electron-patches.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { SimpleGit } from 'simple-git';
 import { log } from '../utils/log-util';
 import { LogLevel } from '../enums';
-import { BackportExtension } from './types';
+import type { BackportExtension } from './types';
 
 // patch content --> array of .patches files that the patch changed
 const getChangedPatchesFiles = (patchContents: string): string[] => {

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,0 +1,9 @@
+export { BackportExtension } from './types';
+export { electronPatchesExtension } from './electron-patches';
+
+import { BackportExtension } from './types';
+import { electronPatchesExtension } from './electron-patches';
+
+export const defaultExtensions: BackportExtension[] = [
+  electronPatchesExtension,
+];

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,8 +1,7 @@
-export { BackportExtension } from './types';
-export { electronPatchesExtension } from './electron-patches';
-
-import { BackportExtension } from './types';
+import type { BackportExtension } from './types';
 import { electronPatchesExtension } from './electron-patches';
+
+export { electronPatchesExtension, type BackportExtension };
 
 export const defaultExtensions: BackportExtension[] = [
   electronPatchesExtension,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,4 +1,4 @@
-import { SimpleGit } from 'simple-git';
+import type { SimpleGit } from 'simple-git';
 
 export interface BackportExtension {
   name: string;

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,0 +1,11 @@
+import { SimpleGit } from 'simple-git';
+
+export interface BackportExtension {
+  name: string;
+  /** Called after a successful `git am` apply. May amend the commit. */
+  afterApply(opts: {
+    git: SimpleGit;
+    dir: string;
+    patch: string;
+  }): Promise<void>;
+}

--- a/src/operations/backport-commits.ts
+++ b/src/operations/backport-commits.ts
@@ -5,6 +5,7 @@ import { BackportOptions } from '../interfaces';
 import { log } from '../utils/log-util';
 import { LogLevel } from '../enums';
 import { isUtf8 } from 'buffer';
+import { defaultExtensions } from '../extensions';
 
 const cleanRawGitString = (s: string) => {
   let nS = s.trim();
@@ -79,6 +80,10 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
     try {
       await fs.promises.writeFile(patchPath, patch, 'utf8');
       await git.raw(['am', '-3', '--keep-cr', patchPath]);
+
+      for (const ext of defaultExtensions) {
+        await ext.afterApply({ git, dir: options.dir, patch });
+      }
     } catch (error) {
       log(
         'backportCommitsToBranch',


### PR DESCRIPTION
Add a special-case handler for Electron `.patches` files to prevent trop from accidentally adding extra patches, ie patches that exist in the source branch but not the target. I've fixed _many_ broken PRs like this so I figured I'd just fix the root problem instead.

Of note: since trop is a general-purpose backport tool, I didn't want to hardcode Electron-specific logic into its core. So I've added a very simple extensions mechanism so plugins can add customized post-git-am processing. That's where I added the `.patches` fix.

All reviews welcomed! CC @codebytere, @dsanders11 as primary stakeholders / most active trop reviewers

--- 

Slop disclaimer:
- `src/` changes were written by me and then reviewed by Opus & Goldeneye.
- `spec/` changes were written by Opus & Goldeneye, then reviewed and revised by me.