### PR TITLE
fix: skip merge commits in `tryBackportAllCommits()`

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -417,7 +417,11 @@ describe('runner', () => {
 
       // Main branch advances with an unrelated commit.
       runGit(sourceDir, ['checkout', 'main']);
-      await writeRepoFile(sourceDir, 'unrelated.txt', 'unrelated-main-change\n');
+      await writeRepoFile(
+        sourceDir,
+        'unrelated.txt',
+        'unrelated-main-change\n',
+      );
       runGit(sourceDir, ['add', 'unrelated.txt']);
       runGit(sourceDir, ['commit', '-m', 'chore: unrelated main change']);
 

--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -384,6 +384,82 @@ describe('runner', () => {
         `${expectedShearedPatches}\n`,
       );
     });
+
+    it('applies only non-merge-commit patches when merge commits are filtered', async () => {
+      const remoteDir = await makeTempDir('trop-remote-');
+      const sourceDir = await makeTempDir('trop-source-');
+      const targetDir = await makeTempDir('trop-target-');
+      const workDir = await makeTempDir('trop-work-');
+
+      runGit(remoteDir, ['init', '--bare']);
+
+      // Shared initial state: a file that both the target branch and the
+      // feature branch start from.
+      for (const dir of [sourceDir, targetDir]) {
+        initTestGitRepo(dir);
+        await writeRepoFile(dir, 'feature.txt', 'initial\n');
+        runGit(dir, ['add', '.']);
+        runGit(dir, ['commit', '-m', 'initial']);
+      }
+      runGit(targetDir, ['branch', '42-x-y']);
+
+      // Feature branch: one real commit (single parent).
+      runGit(sourceDir, ['checkout', '-b', 'feature']);
+      await writeRepoFile(sourceDir, 'feature.txt', 'feature-change\n');
+      runGit(sourceDir, ['add', 'feature.txt']);
+      runGit(sourceDir, ['commit', '-m', 'feat: change feature file']);
+      const featurePatch = runGit(sourceDir, [
+        'format-patch',
+        '-1',
+        '--stdout',
+        'HEAD',
+      ]);
+
+      // Main branch advances with an unrelated commit.
+      runGit(sourceDir, ['checkout', 'main']);
+      await writeRepoFile(sourceDir, 'unrelated.txt', 'unrelated-main-change\n');
+      runGit(sourceDir, ['add', 'unrelated.txt']);
+      runGit(sourceDir, ['commit', '-m', 'chore: unrelated main change']);
+
+      // Merge main back into feature — this is the merge commit (two parents)
+      // that tryBackportAllCommits now filters out.
+      runGit(sourceDir, ['checkout', 'feature']);
+      runGit(sourceDir, ['merge', 'main', '--no-edit', '--no-ff']);
+
+      // Set up remote / work / target for the backport operation.
+      runGit(targetDir, ['remote', 'add', 'origin', remoteDir]);
+      runGit(targetDir, ['push', 'origin', 'main', '42-x-y']);
+      runGit(remoteDir, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+      runGit(workDir, ['clone', remoteDir, '.']);
+      runGit(workDir, ['config', 'user.name', 'Trop Test']);
+      runGit(workDir, ['config', 'user.email', 'trop@example.com']);
+      runGit(workDir, ['remote', 'add', 'target_repo', remoteDir]);
+      runGit(workDir, ['fetch', 'target_repo']);
+
+      // Pass only the single-parent (non-merge) patch — mirroring what
+      // tryBackportAllCommits does after filtering out merge commits.
+      const result = await backportCommitsToBranch({
+        context: {} as never,
+        dir: workDir,
+        github: {} as never,
+        patches: [featurePatch],
+        shouldPush: false,
+        slug: 'electron/trop',
+        targetBranch: '42-x-y',
+        targetRemote: 'target_repo',
+        tempBranch: 'backport-to-42-x-y',
+      });
+      expect(result).toEqual({ dir: workDir });
+
+      // The feature commit's change must be present.
+      expect(
+        await fs.promises.readFile(path.join(workDir, 'feature.txt'), 'utf8'),
+      ).toBe('feature-change\n');
+
+      // The unrelated change introduced by the main-branch commit (which was
+      // only reachable via the merge commit) must NOT be present.
+      expect(fs.existsSync(path.join(workDir, 'unrelated.txt'))).toBe(false);
+    });
   });
 
   describe('updateManualBackport()', { timeout: 30_000 }, () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,12 +96,23 @@ const tryBackportAllCommits = async (opts: TryBackportOptions) => {
   const { context } = opts;
   if (!context) return;
 
-  const commits = (
-    await context.octokit.paginate(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits',
-      context.repo({ pull_number: opts.pr.number, per_page: 100 }),
-    )
-  ).map((commit) => commit.sha);
+  const allCommits = await context.octokit.paginate(
+    'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits',
+    context.repo({ pull_number: opts.pr.number, per_page: 100 }),
+  );
+
+  const mergeCommits = allCommits.filter((c) => c.parents.length > 1);
+  if (mergeCommits.length > 0) {
+    log(
+      'backportImpl',
+      LogLevel.INFO,
+      `Skipping ${mergeCommits.length} merge commit(s) from PR #${opts.pr.number}: ${mergeCommits.map((c) => c.sha).join(', ')}`,
+    );
+  }
+
+  const commits = allCommits
+    .filter((commit) => commit.parents.length <= 1)
+    .map((commit) => commit.sha);
 
   if (commits.length === 0) {
     log(


### PR DESCRIPTION
When a PR author merges the base branch into their feature branch before squash-merging, GitHub's "List PR commits" API includes the merge commit. The commit-patch endpoint for that merge returns a multi-patch mbox containing individual patches for every commit from the merged-in side. `git am -3` applies all of them, pulling unrelated changes into the backport.

The fix filters out commits with multiple parents (merge commits) from the commit list before fetching patches. The GitHub PR commits endpoint already provides the `parents` array, so no extra API call is needed.

Ref: electron/electron#51606, a backport of electron/electron#51586 that pulled in unrelated squirrel.mac and `CHROMIUM_BUILDTOOLS_PATH` changes due to a "Merge branch 'main' into ..." commit in the source PR).