### PR TITLE
test: disable autoDetach for git maintenance

### DIFF
--- a/spec/operations.spec.ts
+++ b/spec/operations.spec.ts
@@ -37,6 +37,8 @@ const runGit = (cwd: string, args: string[]) => {
 
 const initTestGitRepo = (dir: string) => {
   runGit(dir, ['init']);
+  runGit(dir, ['config', 'gc.autoDetach', 'false']);
+  runGit(dir, ['config', 'maintenance.autoDetach', 'false']);
   runGit(dir, ['checkout', '-b', 'main']);
   runGit(dir, ['config', 'user.name', 'Trop Test']);
   runGit(dir, ['config', 'user.email', 'trop@example.com']);
@@ -103,7 +105,9 @@ describe('runner', () => {
     beforeEach(async () => {
       dir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'trop-spec-'));
       await fs.promises.mkdir(dir, { recursive: true });
-      spawnSync('git', ['init'], { cwd: dir });
+      runGit(dir, ['init']);
+      runGit(dir, ['config', 'gc.autoDetach', 'false']);
+      runGit(dir, ['config', 'maintenance.autoDetach', 'false']);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
We're seeing flakes in the tests due to Git running background maintenance that prevents us from removing directories recursively after test runs.

Ran this 5 times in CI and no flakes happened, so I'm confident enough this fixes the flake.