### PR TITLE
feat: add /trop update-branch command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,10 @@ and update the labels appropriately.
 **Note**
   - You can delete the original PR branch whenever you want - trop does not need the original branch to perform the backport.
 
+**Updating a Backport Branch**:
+1. On an open pull request whose branch has fallen behind its base branch, create a new comment with the following body: `/trop update-branch`
+2. `trop` will merge the latest changes from the base branch into the pull request's branch (the same operation as the "Update branch" button, but attributed to trop)
+
 #### Environment Variables
 
 `trop` is configured by default to use variable specific to electron, so in order to get the best experience you should be sure to set the following:

--- a/spec/fixtures/issue_comment_update_branch.created.json
+++ b/spec/fixtures/issue_comment_update_branch.created.json
@@ -1,0 +1,42 @@
+{
+  "name": "issue_comment",
+  "payload": {
+    "action": "created",
+    "issue": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pull/1234",
+      "html_url": "https://github.com/codebytere/public-repo/pull/1234",
+      "number": 1234,
+      "title": "Spelling error in the README file",
+      "user": {
+        "login": "codebytere"
+      },
+      "labels": [
+        {
+          "url": "https://api.github.com/repos/codebytere/public-repo/labels/target/X-X-X",
+          "name": "target/X-X-X",
+          "color": "fc2929"
+        }
+      ],
+      "body": "It looks like you accidently spelled 'commit' with two 't's."
+    },
+    "comment": {
+      "url": "https://api.github.com/repos/codebytere/public-repo/pulls/comments/123456789",
+      "html_url": "https://github.com/codebytere/public-repo/pulls/2#issuecomment-123456789",
+      "id": 99262140,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "/trop update-branch"
+    },
+    "repository": {
+      "name": "public-repo",
+      "full_name": "codebytere/public-repo",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -20,7 +20,11 @@ import {
 } from '../src/operations/backport-to-location';
 import { updateManualBackport } from '../src/operations/update-manual-backport';
 
-import { labelClosedPR, getPRNumbersFromPRBody } from '../src/utils';
+import {
+  labelClosedPR,
+  getPRNumbersFromPRBody,
+  updatePRBranch,
+} from '../src/utils';
 import * as checkUtils from '../src/utils/checks-util';
 
 // event fixtures
@@ -29,6 +33,7 @@ const issueCommentBackportCreatedEvent = require('./fixtures/issue_comment_backp
 const issueCommentBackportToCreatedEvent = require('./fixtures/issue_comment_backport_to.created.json');
 const issueCommentBackportToMultipleCreatedEvent = require('./fixtures/issue_comment_backport_to_multiple.created.json');
 const issueCommentBackportToMultipleCreatedSpacesEvent = require('./fixtures/issue_comment_backport_to_multiple_spaces.created.json');
+const issueCommentUpdateBranchCreatedEvent = require('./fixtures/issue_comment_update_branch.created.json');
 
 const backportPRMergedBotEvent = require('./fixtures/backport_pull_request.merged.bot.json');
 const backportPRClosedBotEvent = require('./fixtures/backport_pull_request.closed.bot.json');
@@ -96,6 +101,7 @@ vi.mock('../src/utils', () => ({
   labelClosedPR: vi.fn(),
   isAuthorizedUser: vi.fn().mockResolvedValue([true]),
   getPRNumbersFromPRBody: vi.fn().mockReturnValue([12345]),
+  updatePRBranch: vi.fn(),
 }));
 
 vi.mock('../src/utils/env-util', () => ({
@@ -335,6 +341,17 @@ describe('trop', () => {
       await robot.receive(issueCommentBackportToCreatedEvent);
 
       expect(backportToBranch).toHaveBeenCalledTimes(0);
+    });
+
+    it('triggers a branch update on `/trop update-branch` comment', async () => {
+      nock(GH_API)
+        .persist()
+        .get('/repos/codebytere/public-repo/pulls/1234')
+        .reply(200, MOCK_PR);
+
+      await robot.receive(issueCommentUpdateBranchCreatedEvent);
+
+      expect(updatePRBranch).toHaveBeenCalled();
     });
   });
 

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as logUtils from '../src/utils/log-util';
 import { LogLevel } from '../src/enums';
-import { tagBackportReviewers } from '../src/utils';
+import { tagBackportReviewers, updatePRBranch } from '../src/utils';
+import type { WebHookPR } from '../src/types';
 
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
+const updateBranchIssueCommentEvent = require('./fixtures/issue_comment_update_branch.created.json');
 
 vi.mock('../src/constants', async () => ({
   ...(await vi.importActual('../src/constants')),
@@ -70,6 +72,76 @@ describe('utils', () => {
         `Failed to request reviewers for PR #1234`,
         error,
       );
+    });
+  });
+
+  describe('updatePRBranch()', () => {
+    const pr = {
+      number: 1234,
+      node_id: 'PR_kwABC',
+      head: { sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e' },
+      base: { ref: 'main' },
+    } as WebHookPR;
+
+    const octokit = {
+      graphql: vi.fn(),
+      issues: {
+        createComment: vi.fn(),
+      },
+    };
+
+    const context = {
+      octokit,
+      repo: vi.fn((obj) => obj),
+      ...updateBranchIssueCommentEvent,
+    };
+
+    beforeEach(() => vi.clearAllMocks());
+
+    it('merges the base branch in via a MERGE updatePullRequestBranch mutation', async () => {
+      context.octokit.graphql.mockResolvedValue({});
+
+      await updatePRBranch(context, pr);
+
+      expect(context.octokit.graphql).toHaveBeenCalledTimes(1);
+
+      const [query, variables] = context.octokit.graphql.mock.calls[0];
+      expect(query).toContain('updatePullRequestBranch');
+      expect(query).toContain('updateMethod: MERGE');
+      expect(variables).toEqual({
+        pullRequestId: 'PR_kwABC',
+        expectedHeadOid: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+      });
+
+      expect(context.octokit.issues.createComment).toHaveBeenCalledWith({
+        issue_number: 1234,
+        body: 'This branch has been updated with the latest changes from `main`.',
+      });
+    });
+
+    it('comments about a merge conflict when the mutation reports one', async () => {
+      const error = new Error(
+        'merge conflict between base and head (updatePullRequestBranch)',
+      );
+      context.octokit.graphql.mockRejectedValue(error);
+
+      await updatePRBranch(context, pr);
+
+      expect(context.octokit.issues.createComment).toHaveBeenCalledWith({
+        issue_number: 1234,
+        body: 'This branch could not be updated because there is a merge conflict with `main`. Please resolve the conflict manually.',
+      });
+    });
+
+    it('comments with a generic failure message on other errors', async () => {
+      context.octokit.graphql.mockRejectedValue(new Error('boom'));
+
+      await updatePRBranch(context, pr);
+
+      expect(context.octokit.issues.createComment).toHaveBeenCalledWith({
+        issue_number: 1234,
+        body: 'I was unable to update this branch with the latest changes from `main`. Please update it manually.',
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   getPRNumbersFromPRBody,
   isAuthorizedUser,
   labelClosedPR,
+  updatePRBranch,
 } from './utils';
 import {
   addLabels,
@@ -662,6 +663,18 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
 
             backportToBranch(robot, context, pr as WebHookPR, branch);
           }
+          return true;
+        },
+      },
+      {
+        name: 'update branch',
+        command: /^update-branch$/,
+        execute: async () => {
+          const { data: pr } = await context.octokit.pulls.get(
+            context.repo({ pull_number: issue.number }),
+          );
+
+          await updatePRBranch(context, pr as WebHookPR);
           return true;
         },
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -461,6 +461,66 @@ export const tagBackportReviewers = async ({
   }
 };
 
+export const updatePRBranch = async (
+  context: SimpleWebHookRepoContext,
+  pr: WebHookPR,
+) => {
+  log(
+    'updatePRBranch',
+    LogLevel.INFO,
+    `Updating #${pr.number} by merging the latest changes from "${pr.base.ref}"`,
+  );
+
+  // Don't use the REBASE update method, as it would create unverified commits
+  const mutation = `mutation UpdatePullRequestBranch($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+    updatePullRequestBranch(input: {
+      pullRequestId: $pullRequestId,
+      expectedHeadOid: $expectedHeadOid,
+      updateMethod: MERGE
+    }) {
+      pullRequest {
+        number
+      }
+    }
+  }`;
+
+  try {
+    await context.octokit.graphql(mutation, {
+      pullRequestId: pr.node_id,
+      expectedHeadOid: pr.head.sha,
+    });
+  } catch (error) {
+    log(
+      'updatePRBranch',
+      LogLevel.ERROR,
+      `Failed to update branch for #${pr.number}`,
+      error,
+    );
+
+    const isConflict = (error as Error)?.message?.includes(
+      'merge conflict between base and head',
+    );
+
+    await context.octokit.issues.createComment(
+      context.repo({
+        issue_number: pr.number,
+        body: isConflict
+          ? `This branch could not be updated because there is a merge conflict with \`${pr.base.ref}\`. Please resolve the conflict manually.`
+          : `I was unable to update this branch with the latest changes from \`${pr.base.ref}\`. Please update it manually.`,
+      }),
+    );
+
+    return;
+  }
+
+  await context.octokit.issues.createComment(
+    context.repo({
+      issue_number: pr.number,
+      body: `This branch has been updated with the latest changes from \`${pr.base.ref}\`.`,
+    }),
+  );
+};
+
 export const backportImpl = async (
   robot: Probot,
   context: SimpleWebHookRepoContext,


### PR DESCRIPTION
In the age of Faraday, it's useful to have a command for trop to merge in the base branch for a maintainer, otherwise a maintainer doing the merge manually will: (1) cause Faraday to ignore that maintainer's approval since they touched the branch and (2) cause Farday to require 2 approvals.

This PR adds a new command a maintainer can use in a comment, `/trop update-branch`, which will have trop do the merge commit and work around the above issues.

I originally was looking to make this `/trop rebase` to align with `@dependabot rebase`, but that required significantly more code and moving pieces, and I think merge commits should work fine for this use case.