### PR TITLE
test: drop mock of getEnvVar

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -104,10 +104,6 @@ vi.mock('../src/utils', () => ({
   updatePRBranch: vi.fn(),
 }));
 
-vi.mock('../src/utils/env-util', () => ({
-  getEnvVar: vi.fn(),
-}));
-
 vi.mock('../src/operations/update-manual-backport', () => ({
   updateManualBackport: vi.fn(),
 }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,10 +267,7 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
         }
 
         const FASTTRACK_PREFIXES = ['build:', 'ci:'];
-        const FASTTRACK_USERS = [
-          getEnvVar('BOT_USER_NAME'),
-          getEnvVar('COMMITTER_USER_NAME'),
-        ];
+        const FASTTRACK_USERS = [getEnvVar('BOT_USER_NAME')];
         const FASTTRACK_LABELS: string[] = ['fast-track 🚅'];
 
         const failureMap = new Map();


### PR DESCRIPTION
This mock prevents testing some code paths because it's just returning `undefined`. There's no reason to do a mock here, we can exercise the real util code.

Removing it exposes that `COMMITTER_USER_NAME` isn't set in tests and is undocumented. Looking at the historical context, it looks like it was originally used for `electron-bot`, but we haven't used that account in ages, so let's just drop the `COMMITTER_USER_NAME` usage as part of this.