### PR TITLE
refactor: remove redundant isAuthorizedUser

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -99,7 +99,7 @@ const backportRequestedLabel = {
 
 vi.mock('../src/utils', () => ({
   labelClosedPR: vi.fn(),
-  isAuthorizedUser: vi.fn().mockResolvedValue([true]),
+  checkUserHasWriteAccess: vi.fn().mockResolvedValue(true),
   getPRNumbersFromPRBody: vi.fn().mockReturnValue([12345]),
   updatePRBranch: vi.fn(),
 }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { ApplicationFunction } from 'probot';
 
 import {
   backportImpl,
+  checkUserHasWriteAccess,
   getPRNumbersFromPRBody,
-  isAuthorizedUser,
   labelClosedPR,
   updatePRBranch,
 } from './utils';
@@ -545,7 +545,7 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
     if (!cmd.startsWith(TROP_COMMAND_PREFIX)) return;
 
     // Allow all users with push access to handle backports.
-    if (!(await isAuthorizedUser(context, comment.user.login))) {
+    if (!(await checkUserHasWriteAccess(context, comment.user.login))) {
       robot.log(
         `@${comment.user.login} is not authorized to run PR backports - stopping`,
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -268,19 +268,6 @@ const tryBackportSquashCommit = async (opts: TryBackportOptions) => {
   return success;
 };
 
-export const isAuthorizedUser = async (
-  context: WebHookIssueContext,
-  username: string,
-) => {
-  const { data } = await context.octokit.repos.getCollaboratorPermissionLevel(
-    context.repo({
-      username,
-    }),
-  );
-
-  return ['admin', 'write'].includes(data.permission);
-};
-
 export const getPRNumbersFromPRBody = (pr: WebHookPR, checkNotBot = false) => {
   const backportNumbers: number[] = [];
 
@@ -362,7 +349,7 @@ export const isSemverMinorPR = async (
   return hasLabel || hasPrefix;
 };
 
-const checkUserHasWriteAccess = async (
+export const checkUserHasWriteAccess = async (
   context: SimpleWebHookRepoContext,
   user: string,
 ) => {


### PR DESCRIPTION
`isAuthorizedUser` and `checkUserHasWriteAccess` are doing the same thing so lets consolidate to just `checkUserHasWriteAccess`.

Also fixes an issue with the mock value which was returning an array instead of a boolean.