### PR TITLE
fix: bot mention in manual backport comments

### DIFF
--- a/src/operations/update-manual-backport.ts
+++ b/src/operations/update-manual-backport.ts
@@ -107,7 +107,11 @@ export const updateManualBackport = async (
     }
 
     // We should only comment if there is not a previous existing comment
-    const commentBody = `@${pr.user.login} has manually backported this PR to "${pr.base.ref}", \
+    // Bot logins include "[bot]" suffix which GitHub can't @mention correctly,
+    // so we use a plain reference for bots instead of a broken @mention.
+    const authorRef =
+      pr.user.type === 'Bot' ? pr.user.login : `@${pr.user.login}`;
+    const commentBody = `${authorRef} has manually backported this PR to "${pr.base.ref}", \
 please check out #${pr.number}`;
 
     // TODO(codebytere): Once probot updates to @octokit/rest@16 we can use .paginate to


### PR DESCRIPTION
## Summary
Fixed an issue where bot accounts were being incorrectly @mentioned in manual backport comments, which GitHub cannot properly handle due to the "[bot]" suffix in bot usernames.

## Changes
- Added logic to detect bot accounts by checking the `pr.user.type` field
- Bot accounts are now referenced by their plain login name instead of using the @mention syntax
- Human users continue to be @mentioned as before using the `@username` format

## Implementation Details
The fix distinguishes between bot and human users when generating the comment body for manual backports. Since GitHub cannot @mention users with "[bot]" in their username, bot accounts are referenced without the @ symbol while maintaining the @mention for regular user accounts. This ensures the comment is properly formatted and readable regardless of the account type that performed the backport.

https://claude.ai/code/session_01GMXJjG5UdfBMktsPULHhJK