### PR TITLE
fix: do not follow symlinks when uploading backport file contents

### DIFF
--- a/src/operations/backport-commits.ts
+++ b/src/operations/backport-commits.ts
@@ -136,7 +136,17 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
           tree: await Promise.all(
             changedFiles.map(async (changedFile) => {
               const onDiskPath = path.resolve(options.dir, changedFile);
-              if (!fs.existsSync(onDiskPath)) {
+
+              // Use lstat (not stat/existsSync) so we never follow symbolic
+              // links. The commit content is attacker-controlled, so a PR can
+              // add a git symlink (mode 120000) pointing at an absolute path on
+              // the trop host (e.g. /proc/self/environ or a secret/token file).
+              // Dereferencing it would upload that file's contents into the
+              // public backport PR. Instead we reproduce the symlink as-is.
+              let stat: fs.Stats;
+              try {
+                stat = await fs.promises.lstat(onDiskPath);
+              } catch {
                 return {
                   path: changedFile,
                   mode: '100644',
@@ -144,8 +154,31 @@ export const backportCommitsToBranch = async (options: BackportOptions) => {
                   sha: null,
                 };
               }
+
+              // Preserve symbolic links as git symlink blobs (mode 120000)
+              // whose content is the link target string itself. readlink does
+              // not dereference the link, so the target file is never read.
+              if (stat.isSymbolicLink()) {
+                const linkTarget = await fs.promises.readlink(onDiskPath);
+                return {
+                  path: changedFile,
+                  mode: '120000',
+                  type: 'blob',
+                  content: linkTarget,
+                };
+              }
+
+              // Only ever read the bytes of regular files.
+              if (!stat.isFile()) {
+                return {
+                  path: changedFile,
+                  mode: '100644',
+                  type: 'blob',
+                  sha: null,
+                };
+              }
+
               const fileContents = await fs.promises.readFile(onDiskPath);
-              const stat = await fs.promises.stat(onDiskPath);
               const userMode = (stat.mode & parseInt('777', 8)).toString(8)[0];
               if (isUtf8(fileContents)) {
                 return {


### PR DESCRIPTION
## Summary
This change fixes a security vulnerability in the backport commits operation by properly handling symbolic links without dereferencing them. Previously, the code could be exploited to read arbitrary files from the host system when processing attacker-controlled commit content.

## Key Changes
- **Replace `existsSync`/`stat` with `lstat`**: Use `lstat` instead of `stat` to avoid following symbolic links, preventing dereference of potentially malicious symlinks pointing to sensitive files (e.g., `/proc/self/environ`, secret tokens)
- **Add explicit symlink handling**: Detect symbolic links using `stat.isSymbolicLink()` and preserve them as git symlink blobs (mode `120000`) with the link target as content
- **Add file type validation**: Only read regular files using `stat.isFile()`, returning null SHA for non-regular, non-symlink entries
- **Improve error handling**: Wrap `lstat` in try-catch to gracefully handle missing files

## Implementation Details
- The fix ensures that symbolic links in commit content are reproduced as-is in the backport PR rather than being dereferenced
- `readlink` is used to get the link target without following the link, so the target file is never actually read
- This prevents a malicious PR from uploading sensitive host files into public backport PRs
- The change maintains backward compatibility for regular files while adding proper security boundaries

https://claude.ai/code/session_011cyiW3zMmZmZ9GF8BbF7Zi