### PR TITLE
fix: fail backport validity check on any invalid reference

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1385,5 +1385,120 @@ Notes: <!-- One-line Change Summary Here-->`,
         conclusion: CheckRunStatus.SUCCESS,
       });
     });
+
+    it('fails the backport validity check if any referenced PR is invalid regardless of ordering', async () => {
+      // An invalid reference listed before a valid one must not be able to
+      // force the aggregate check green via last-write-wins ordering.
+      vi.mocked(getPRNumbersFromPRBody).mockReturnValueOnce([1234, 5678]);
+
+      const event = JSON.parse(
+        await fs.readFile(newPRBackportOpenedEventPath, 'utf-8'),
+      );
+      event.payload.pull_request.base.ref = '30-x-y';
+      event.payload.action = 'synchronize';
+
+      // First reference: invalid (not merged).
+      nock(GH_API)
+        .persist()
+        .get('/repos/codebytere/probot-test/pulls/1234')
+        .reply(200, {
+          merged: false,
+          base: {
+            ref: 'main',
+          },
+        });
+
+      // Second reference: a real, merged PR targeting the default branch.
+      nock(GH_API)
+        .persist()
+        .get('/repos/codebytere/probot-test/pulls/5678')
+        .reply(200, {
+          merged: true,
+          base: {
+            ref: 'main',
+          },
+        });
+
+      nock(GH_API)
+        .persist()
+        .get(
+          '/repos/codebytere/probot-test/commits/ABC/check-runs?per_page=100',
+        )
+        .reply(200, {
+          check_runs: [
+            {
+              name: BACKPORT_APPROVAL_CHECK,
+            },
+          ],
+        });
+
+      nock(GH_API)
+        .get('/repos/codebytere/probot-test/branches?protected=true')
+        .reply(200, BRANCHES);
+
+      nock(GH_API)
+        .persist()
+        .get(
+          `/repos/codebytere/probot-test/issues/${event.payload.pull_request.number}/labels?per_page=100&page=1`,
+        )
+        .reply(200, event.payload.pull_request.labels);
+
+      await robot.receive(event);
+
+      // The check run must be updated exactly once with a FAILURE conclusion -
+      // it must not be overwritten to SUCCESS by the trailing valid reference.
+      const validityCalls = vi.mocked(checkUtils.updateBackportValidityCheck)
+        .mock.calls;
+      expect(validityCalls).toHaveLength(1);
+      expect(validityCalls[0][2]).toMatchObject({
+        title: 'Invalid Backport',
+        conclusion: CheckRunStatus.FAILURE,
+      });
+    });
+
+    it('keeps the backport validity check failed for a non-fast-track PR with no backport declaration', async () => {
+      // A PR targeting a release branch with no "Backport of #N" declaration
+      // that does not qualify for fast-track must FAIL - and the aggregation
+      // of declared references must not overwrite that failure with success.
+      vi.mocked(getPRNumbersFromPRBody).mockReturnValueOnce([]);
+
+      const event = JSON.parse(
+        await fs.readFile(newPRBackportOpenedEventPath, 'utf-8'),
+      );
+      event.payload.pull_request.base.ref = '30-x-y';
+      event.payload.action = 'synchronize';
+
+      nock(GH_API)
+        .persist()
+        .get(
+          '/repos/codebytere/probot-test/commits/ABC/check-runs?per_page=100',
+        )
+        .reply(200, {
+          check_runs: [
+            {
+              name: BACKPORT_APPROVAL_CHECK,
+            },
+          ],
+        });
+
+      nock(GH_API)
+        .persist()
+        .get(
+          `/repos/codebytere/probot-test/issues/${event.payload.pull_request.number}/labels?per_page=100&page=1`,
+        )
+        .reply(200, event.payload.pull_request.labels);
+
+      await robot.receive(event);
+
+      // The fast-track branch must be the sole updater here - exactly one
+      // FAILURE call, never overwritten to SUCCESS by the aggregation block.
+      const validityCalls = vi.mocked(checkUtils.updateBackportValidityCheck)
+        .mock.calls;
+      expect(validityCalls).toHaveLength(1);
+      expect(validityCalls[0][2]).toMatchObject({
+        title: 'Invalid Backport',
+        conclusion: CheckRunStatus.FAILURE,
+      });
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,27 +333,45 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
               failureMap.set(oldPRNumber, cause);
             }
           }
-        }
 
-        for (const oldPRNumber of oldPRNumbers) {
-          if (failureMap.has(oldPRNumber)) {
+          // The validity check must reflect the worst-case result across ALL
+          // declared backport references. If any referenced PR is invalid the
+          // aggregate check must conclude FAILURE regardless of the order in
+          // which the references appear in the PR body. Compute a single
+          // conclusion from the full failureMap rather than overwriting the
+          // same check run once per reference (which would be last-write-wins
+          // and let an author bury an invalid reference behind a valid one).
+          const invalidPRNumbers = oldPRNumbers.filter((oldPRNumber) =>
+            failureMap.has(oldPRNumber),
+          );
+
+          if (invalidPRNumbers.length > 0) {
+            const firstInvalid = invalidPRNumbers[0];
             robot.log(
               `#${pr.number} is targeting a branch that is not ${
                 pr.base.repo.default_branch
-              } - ${failureMap.get(oldPRNumber)}`,
+              } - ${failureMap.get(firstInvalid)}`,
             );
             await updateBackportValidityCheck(context, checkRun, {
               title: 'Invalid Backport',
               summary: `This PR is targeting a branch that is not ${
                 pr.base.repo.default_branch
-              } but ${failureMap.get(oldPRNumber)}`,
+              } but ${failureMap.get(firstInvalid)}`,
               conclusion: CheckRunStatus.FAILURE,
             });
           } else {
-            robot.log(`#${pr.number} is a valid backport of #${oldPRNumber}`);
+            robot.log(
+              `#${pr.number} is a valid backport of ${oldPRNumbers
+                .map((oldPRNumber) => `#${oldPRNumber}`)
+                .join(', ')}`,
+            );
             await updateBackportValidityCheck(context, checkRun, {
               title: 'Valid Backport',
-              summary: `This PR is declared as backporting "#${oldPRNumber}" which is a valid PR that has been merged into ${pr.base.repo.default_branch}`,
+              summary: `This PR is declared as backporting ${oldPRNumbers
+                .map((oldPRNumber) => `"#${oldPRNumber}"`)
+                .join(
+                  ', ',
+                )} which is a valid PR that has been merged into ${pr.base.repo.default_branch}`,
               conclusion: CheckRunStatus.SUCCESS,
             });
           }


### PR DESCRIPTION
## Summary
Fixed a bug in the backport validity check logic where an invalid PR reference could be masked by a valid one due to last-write-wins ordering. The check now evaluates all declared backport references and fails if ANY of them are invalid, regardless of their order in the PR body.

## Key Changes
- **Aggregated validity assessment**: Changed from checking references one-at-a-time (which could be overwritten) to computing a single conclusion from all references before updating the check run
- **Worst-case evaluation**: The check now fails if any referenced PR is invalid, ensuring that authors cannot bury invalid references behind valid ones
- **Improved logging**: Updated log messages to handle multiple backport references and report the first invalid reference when applicable
- **Enhanced summary messages**: Check run summaries now properly list all declared backport references using comma-separated formatting

## Implementation Details
- Moved the check run update logic inside the reference validation loop to operate on the complete `failureMap` rather than updating incrementally
- Filter `oldPRNumbers` to identify all invalid references upfront
- Report the first invalid reference's failure reason in the check run summary
- Format multiple valid references in success messages for clarity

https://claude.ai/code/session_01YJ5unkitrn3QapEr2TAxnj