### PR TITLE
fix: add symlink and path traversal protections to patches file handling

### DIFF
--- a/src/extensions/electron-patches.ts
+++ b/src/extensions/electron-patches.ts
@@ -14,6 +14,112 @@ const getChangedPatchesFiles = (patchContents: string): string[] => {
     .filter((file, idx, arr) => arr.indexOf(file) === idx); // no dupes
 };
 
+// Is `child` the same as, or nested inside, `parent`? Purely lexical — both
+// paths must already be resolved/absolute.
+const isInside = (parent: string, child: string): boolean => {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+};
+
+// `.patches` file paths come straight out of untrusted patch text, so a
+// malicious commit can point them at a symlink (mode 120000) or use `..` to
+// escape the working tree. Resolve the path defensively and confirm it is a
+// regular file that lives inside the repo — following no symbolic links along
+// the way — before we ever read or overwrite it. Returns the safe absolute
+// path, or null if the path should be skipped.
+const resolveSafePatchesPath = (
+  repoRealDir: string,
+  patchesPath: string,
+): string | null => {
+  const absPath = path.resolve(repoRealDir, patchesPath);
+
+  // Reject anything that lexically escapes the working tree (e.g. via `..`).
+  if (!isInside(repoRealDir, absPath)) {
+    return null;
+  }
+
+  // Walk every path component and reject if any of them is a symbolic link.
+  // This defeats both a symlinked `.patches` file and a symlinked parent
+  // directory that would otherwise redirect the write outside the repo.
+  let cursor = repoRealDir;
+  const segments = path.relative(repoRealDir, absPath).split(path.sep);
+  for (const segment of segments) {
+    if (segment === '' || segment === '.') continue;
+    cursor = path.join(cursor, segment);
+    let stats: fs.Stats;
+    try {
+      stats = fs.lstatSync(cursor);
+    } catch {
+      // Component does not exist yet (the `.patches` file or its parent dirs
+      // may be created later) — nothing to follow, so this segment is safe.
+      continue;
+    }
+    if (stats.isSymbolicLink()) {
+      return null;
+    }
+  }
+
+  // If the target already exists it must be a regular file, never a symlink,
+  // FIFO, device, directory, etc.
+  if (fs.existsSync(absPath) && !fs.lstatSync(absPath).isFile()) {
+    return null;
+  }
+
+  return absPath;
+};
+
+// Read a file without following a symlink as its final component. Returns ''
+// when the file does not exist, or null if the path is (or raced into being) a
+// symbolic link. The O_NOFOLLOW flag closes the TOCTOU gap between the path
+// validation above and the actual read.
+const readFileNoFollow = async (absPath: string): Promise<string | null> => {
+  let fd: fs.promises.FileHandle;
+  try {
+    fd = await fs.promises.open(
+      absPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return '';
+    if (code === 'ELOOP') return null;
+    throw err;
+  }
+  try {
+    return await fd.readFile('utf8');
+  } finally {
+    await fd.close();
+  }
+};
+
+// Write a file without following a symlink as its final component, returning
+// false if the target is (or raced into being) a symbolic link.
+const writeFileNoFollow = async (
+  absPath: string,
+  content: string,
+): Promise<boolean> => {
+  let fd: fs.promises.FileHandle;
+  try {
+    fd = await fs.promises.open(
+      absPath,
+      fs.constants.O_WRONLY |
+        fs.constants.O_CREAT |
+        fs.constants.O_TRUNC |
+        fs.constants.O_NOFOLLOW,
+      0o644,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ELOOP') return false;
+    throw err;
+  }
+  try {
+    await fd.writeFile(content, 'utf8');
+    return true;
+  } finally {
+    await fd.close();
+  }
+};
+
 // Handles a special case for Electron `.patches` files: `git am` can pull
 // in extra context lines. But this breaks us because those extra lines
 // are for .patch files that don't exist in the target branch.
@@ -27,12 +133,30 @@ const applyPatchesChanges = async (
   const lf = '\n';
   let shouldAmend = false;
 
+  // Resolve the working tree once so symlinked path components can be compared
+  // against its canonical location.
+  const repoRealDir = fs.realpathSync(repoDir);
+
   for (const patchesPath of getChangedPatchesFiles(patchContents)) {
     const patchDir = path.posix.dirname(patchesPath);
-    const absPath = path.resolve(repoDir, patchesPath);
-    const current = fs.existsSync(absPath)
-      ? await fs.promises.readFile(absPath, 'utf8')
-      : '';
+    const absPath = resolveSafePatchesPath(repoRealDir, patchesPath);
+    if (absPath === null) {
+      log(
+        'backportCommitsToBranch',
+        LogLevel.WARN,
+        `Refusing to process untrusted .patches path outside the working tree or via a symlink: ${patchesPath}`,
+      );
+      continue;
+    }
+    const current = await readFileNoFollow(absPath);
+    if (current === null) {
+      log(
+        'backportCommitsToBranch',
+        LogLevel.WARN,
+        `Refusing to read .patches file through a symlink: ${patchesPath}`,
+      );
+      continue;
+    }
 
     const isPatchFile = (f: string): boolean =>
       !f.startsWith('#') && f.endsWith('.patch');
@@ -41,10 +165,11 @@ const applyPatchesChanges = async (
       .split(/\r?\n/)
       .filter((line) => {
         const trimmed = line.trim();
-        return (
-          !isPatchFile(trimmed) ||
-          fs.existsSync(path.resolve(repoDir, patchDir, trimmed))
-        );
+        if (!isPatchFile(trimmed)) return true;
+        // `trimmed` is sibling-file content from the (untrusted) patch; only
+        // probe paths that stay within the working tree.
+        const candidate = path.resolve(repoRealDir, patchDir, trimmed);
+        return isInside(repoRealDir, candidate) && fs.existsSync(candidate);
       })
       .join(newline);
 
@@ -57,7 +182,14 @@ const applyPatchesChanges = async (
     );
 
     await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
-    await fs.promises.writeFile(absPath, newContent, 'utf8');
+    if (!(await writeFileNoFollow(absPath, newContent))) {
+      log(
+        'backportCommitsToBranch',
+        LogLevel.WARN,
+        `Refusing to write .patches file through a symlink: ${patchesPath}`,
+      );
+      continue;
+    }
     await git.add(patchesPath);
     shouldAmend = true;
   }


### PR DESCRIPTION
## Summary
This change hardens the electron-patches file handling to prevent security vulnerabilities from malicious patch files that could exploit symlinks or path traversal attacks to read/write files outside the repository.

## Key Changes
- **Added `isInside()` helper**: Performs lexical path containment checks to ensure paths don't escape the working tree via `..` or absolute paths
- **Added `resolveSafePatchesPath()`**: Safely resolves `.patches` file paths by:
  - Rejecting paths that lexically escape the working tree
  - Walking each path component and rejecting any symbolic links encountered
  - Validating that existing targets are regular files, not symlinks or other special files
- **Added `readFileNoFollow()`**: Reads files using `O_NOFOLLOW` flag to prevent following symlinks as the final component, closing TOCTOU gaps
- **Added `writeFileNoFollow()`**: Writes files using `O_NOFOLLOW` flag to prevent writing through symlinks
- **Updated `applyPatchesChanges()`**: 
  - Uses the new safe path resolution and file I/O functions
  - Adds validation when filtering patch file references to ensure candidate paths stay within the working tree
  - Logs warnings when untrusted paths are rejected

## Notable Implementation Details
- Uses `fs.realpathSync()` to resolve the repository directory once at the start, allowing symlinked path components to be safely compared against the canonical location
- Leverages Node.js `fs.constants.O_NOFOLLOW` flag to atomically prevent symlink following during file operations
- Distinguishes between different error conditions (ENOENT for missing files, ELOOP for symlinks) to provide appropriate handling
- Maintains backward compatibility while adding security checks that skip malicious paths with appropriate warnings

https://claude.ai/code/session_01XSfnUjCm4ZCuFq1bZJaeoB