### PR TITLE
fix: prevent git argument injection via untrusted .patches path

### DIFF
--- a/src/extensions/electron-patches.ts
+++ b/src/extensions/electron-patches.ts
@@ -190,7 +190,11 @@ const applyPatchesChanges = async (
       );
       continue;
     }
-    await git.add(patchesPath);
+    // Stage via a raw invocation with an explicit end-of-options separator and
+    // the validated absolute path. The untrusted patch-derived path may begin
+    // with a dash (e.g. `--foo/.patches`); without `--`, git would parse it as
+    // a command-line option rather than a pathspec (CWE-88 argument injection).
+    await git.raw(['add', '--', absPath]);
     shouldAmend = true;
   }
 


### PR DESCRIPTION
## Summary
Fixed a command injection vulnerability (CWE-88) in the electron patches extension where untrusted patch-derived file paths could be interpreted as git command-line options.

## Key Changes
- Changed `git.add(patchesPath)` to `git.raw(['add', '--', absPath])` to safely stage patch files
- Added explicit end-of-options separator (`--`) to prevent paths starting with dashes from being parsed as options
- Updated to use the validated absolute path (`absPath`) instead of the potentially untrusted `patchesPath`

## Implementation Details
The vulnerability existed because patch-derived paths (e.g., `--foo/.patches`) could begin with a dash, causing git to misinterpret them as command-line options rather than file paths. By using `git.raw()` with the `--` separator, we ensure the path is always treated as a pathspec regardless of its content. The use of the absolute path provides additional validation and safety.

https://claude.ai/code/session_01H1eqXgK6rfdbiQJbJd3pmw