### PR TITLE
docs: remove CoC reference from contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,6 @@
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-This project adheres to the Contributor Covenant
-[code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code.
-
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository


### PR DESCRIPTION
Given that [the CoC document is up to date in the ](https://github.com/electron/.github/pull/53)[`.github`](https://github.com/electron/.github/pull/53)[ repository](https://github.com/electron/.github/pull/53), this reference should be removed so that the `.github` CoC is the only one visible and mentioned in this repository.