### PR TITLE
fix: never supersede a concluded backport approval check from the opened event

### DIFF
--- a/spec/checks-util.spec.ts
+++ b/spec/checks-util.spec.ts
@@ -100,5 +100,63 @@ describe('checks-util', () => {
         }),
       );
     });
+
+    it('leaves a completed check run alone when superseding is not permitted', async () => {
+      // Regression test for electron/electron#53332: a caller that only
+      // wants a pending run to exist must not turn a verdict that a
+      // concurrent delivery already settled back into a queued run that no
+      // follow-up event would complete.
+      octokit.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [
+            {
+              id: 12345,
+              name: BACKPORT_APPROVAL_CHECK,
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        },
+      });
+
+      await queueBackportApprovalCheck(context, { supersedeCompleted: false });
+
+      expect(octokit.checks.update).not.toHaveBeenCalled();
+      expect(octokit.checks.create).not.toHaveBeenCalled();
+    });
+
+    it('still creates a queued check run when none exists and superseding is not permitted', async () => {
+      octokit.checks.listForRef.mockResolvedValue({
+        data: { check_runs: [] },
+      });
+
+      await queueBackportApprovalCheck(context, { supersedeCompleted: false });
+
+      expect(octokit.checks.create).toHaveBeenCalledTimes(1);
+      expect(octokit.checks.update).not.toHaveBeenCalled();
+    });
+
+    it('still resets a pending check run when superseding is not permitted', async () => {
+      octokit.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [
+            {
+              id: 12345,
+              name: BACKPORT_APPROVAL_CHECK,
+              status: 'queued',
+              conclusion: null,
+            },
+          ],
+        },
+      });
+
+      await queueBackportApprovalCheck(context, { supersedeCompleted: false });
+
+      expect(octokit.checks.create).not.toHaveBeenCalled();
+      expect(octokit.checks.update).toHaveBeenCalledTimes(1);
+      expect(octokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({ check_run_id: 12345, status: 'queued' }),
+      );
+    });
   });
 });

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -499,19 +499,22 @@ describe('trop', () => {
       expect(checkUtils.updateBackportApprovalCheck).not.toHaveBeenCalled();
     });
 
-    it('keeps the backport approval check pending when a backport is opened before its labels have settled', async () => {
-      // Regression test for electron/electron#53035: a declared backport's
-      // labels are written by trop itself - backportImpl labels trop-created
-      // backports shortly after opening them, and updateManualBackport
-      // labels manually-opened backports. Regardless of author, the
-      // `opened` evaluation can therefore see no labels at all, and
-      // concluding "not required" in that window is premature - the verdict
+    it('keeps the backport approval check pending when a trop-created backport is opened before its labels have settled', async () => {
+      // Regression test for electron/electron#53035: backportImpl labels
+      // trop-created backports in a separate API call shortly after opening
+      // them, so the `opened` evaluation can see no labels at all.
+      // Concluding "not required" in that window is premature - the verdict
       // must stay pending until the labeled events that follow trop's label
       // writes settle it.
       getBackportApprovalCheck.mockResolvedValueOnce({
         name: BACKPORT_APPROVAL_CHECK,
         status: 'queued',
       });
+
+      const event = JSON.parse(
+        await fs.readFile(newPRBackportOpenedEventPath, 'utf-8'),
+      );
+      event.payload.pull_request.user.login = BOT_USER_NAME;
 
       nock(GH_API)
         .persist()
@@ -530,12 +533,61 @@ describe('trop', () => {
         )
         .reply(200, []);
 
-      await robot.receive(backportPROpenedEvent);
+      await robot.receive(event);
 
       expect(checkUtils.updateBackportApprovalCheck).not.toHaveBeenCalled();
       // Once to create the missing check run, once to (re-)assert the
-      // pending state after evaluating the live labels.
+      // pending state after evaluating the live labels. Neither may
+      // supersede a run that a concurrent labeled delivery already
+      // concluded.
       expect(checkUtils.queueBackportApprovalCheck).toHaveBeenCalledTimes(2);
+      expect(checkUtils.queueBackportApprovalCheck).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { supersedeCompleted: false },
+      );
+    });
+
+    it('concludes "Not Required" on opened for a manual backport whose live labels do not request approval', async () => {
+      // Regression test for electron/electron#53332: a manually-opened
+      // backport is labeled by updateManualBackport in this same handler,
+      // before the live labels are read. The verdict is therefore already
+      // settled on `opened` and must be concluded here - deferring it to a
+      // labeled event that has usually already been processed left the
+      // check queued forever.
+      nock(GH_API)
+        .persist()
+        .get('/repos/codebytere/probot-test/pulls/12345')
+        .reply(200, MOCK_PR);
+
+      nock(GH_API)
+        .get('/repos/codebytere/probot-test/branches?protected=true')
+        .reply(200, BRANCHES);
+
+      nock(GH_API)
+        .persist()
+        .get(
+          '/repos/codebytere/probot-test/issues/7/labels?per_page=100&page=1',
+        )
+        .reply(200, [
+          { name: 'backport', color: 'fff' },
+          { name: 'semver/patch', color: 'fff' },
+        ]);
+
+      await robot.receive(backportPROpenedEvent);
+
+      expect(updateManualBackport).toHaveBeenCalled();
+      // Only the creation of the missing check run.
+      expect(checkUtils.queueBackportApprovalCheck).toHaveBeenCalledTimes(1);
+
+      const updatePayload = vi.mocked(checkUtils.updateBackportApprovalCheck)
+        .mock.calls[0][2];
+
+      expect(updatePayload).toMatchObject({
+        title: 'Backport Approval Not Required',
+        summary: `This PR does not need backport approval.`,
+        conclusion: CheckRunStatus.SUCCESS,
+      });
     });
 
     it('concludes "Not Required" on opened for a release-branch PR with no backport declaration', async () => {
@@ -543,10 +595,8 @@ describe('trop', () => {
       // are never labeled by trop, so no labeled event is guaranteed to
       // arrive. The `opened` evaluation must conclude for them - leaving
       // the check queued would hang it forever.
-      // Consumed by the manual-backport scan and the declaration guard.
-      vi.mocked(getPRNumbersFromPRBody)
-        .mockReturnValueOnce([])
-        .mockReturnValueOnce([]);
+      // Consumed by the manual-backport scan.
+      vi.mocked(getPRNumbersFromPRBody).mockReturnValueOnce([]);
 
       nock(GH_API)
         .persist()
@@ -635,12 +685,19 @@ describe('trop', () => {
       expect(checkUtils.queueBackportApprovalCheck).toHaveBeenCalledTimes(2);
     });
 
-    it('does not re-queue a concluded backport approval check when `opened` is delivered late', async () => {
+    it("does not supersede a concluded backport approval check when a trop-created backport's `opened` is delivered late", async () => {
       // Webhook deliveries can be reordered: a labeled delivery processed
       // before the `opened` one has already settled the verdict from the
       // live labels. The late `opened` evaluation must not supersede that
       // concluded run with a queued one - no follow-up event would ever
-      // complete it.
+      // complete it. The snapshot taken at the top of the handler is stale
+      // by the time the verdict is evaluated, so the pending state is
+      // (re-)asserted without permission to supersede and the decision is
+      // made against the live run inside queueBackportApprovalCheck.
+      const event = JSON.parse(
+        await fs.readFile(newPRBackportOpenedEventPath, 'utf-8'),
+      );
+      event.payload.pull_request.user.login = BOT_USER_NAME;
 
       // Replace the beforeEach interceptor that reports no check runs.
       nock.cleanAll();
@@ -679,10 +736,14 @@ describe('trop', () => {
         )
         .reply(200, [{ name: 'backport', color: 'fff' }]);
 
-      await robot.receive(backportPROpenedEvent);
+      await robot.receive(event);
 
       expect(checkUtils.updateBackportApprovalCheck).not.toHaveBeenCalled();
-      expect(checkUtils.queueBackportApprovalCheck).not.toHaveBeenCalled();
+      expect(checkUtils.queueBackportApprovalCheck).toHaveBeenCalledTimes(1);
+      expect(checkUtils.queueBackportApprovalCheck).toHaveBeenCalledWith(
+        expect.anything(),
+        { supersedeCompleted: false },
+      );
     });
 
     it('passes the backport approval check if the "backport/approved" label is on a new backport PR', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,12 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
 
       if (pr.base.ref !== pr.base.repo.default_branch) {
         if (!backportApprovalCheck) {
-          await queueBackportApprovalCheck(context);
+          // Only ensure a run exists here - a concurrent delivery may have
+          // created and concluded one since the snapshot above, and that
+          // verdict must not be superseded by a queued run.
+          await queueBackportApprovalCheck(context, {
+            supersedeCompleted: false,
+          });
           backportApprovalCheck = (await getBackportApprovalCheck(context))!;
         }
 
@@ -418,28 +423,32 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
             await queueBackportApprovalCheck(context);
           } else if (
             action === 'opened' &&
-            getPRNumbersFromPRBody(pr).length > 0
+            pr.user.login === getEnvVar('BOT_USER_NAME')
           ) {
-            // A declared backport's labels are written by trop, not by its
-            // author: backportImpl labels trop-created backports in a
-            // separate API call shortly after opening them, and
-            // updateManualBackport labels manually-opened backports (with
-            // at least the base-ref label). On `opened` those labels may
-            // still be in flight, so an empty label set must not conclude
-            // "not required" - keep the check pending and let the labeled
-            // events that follow trop's label writes settle the verdict.
-            // This applies to every declared backport regardless of author;
-            // PRs without a backport declaration (e.g. fast-track PRs) get
-            // no guaranteed labeled event, so they still conclude below.
+            // A trop-created backport is labeled by backportImpl in a
+            // separate API call shortly after the PR is opened, so on
+            // `opened` the live labels may still be empty and an empty label
+            // set must not conclude "not required" - keep the check pending
+            // and let the labeled events that follow trop's label writes
+            // settle the verdict.
             //
-            // Webhook deliveries can be reordered: when a labeled delivery
-            // was processed before this `opened` one, the verdict was
-            // already settled from the same live labels consulted above -
-            // don't supersede a concluded run with a queued one that no
-            // follow-up event would ever complete.
-            if (backportApprovalCheck.status !== 'completed') {
-              await queueBackportApprovalCheck(context);
-            }
+            // This is specific to trop-authored PRs: a manually-opened
+            // backport is labeled by updateManualBackport *in this same
+            // handler* before the live labels were read above, so its
+            // verdict is already settled and it concludes below. PRs without
+            // a backport declaration (e.g. fast-track PRs) get no guaranteed
+            // labeled event at all, so they must conclude below too.
+            //
+            // Deliveries race: the labeled events may already have been
+            // processed and concluded the run by the time this slow `opened`
+            // handler gets here (it ran the manual-backport bookkeeping
+            // first). Never supersede a concluded run from this path - the
+            // snapshot taken above is stale, so the decision is made against
+            // the live run inside queueBackportApprovalCheck
+            // (electron/electron#53332).
+            await queueBackportApprovalCheck(context, {
+              supersedeCompleted: false,
+            });
           } else {
             await updateBackportApprovalCheck(context, backportApprovalCheck, {
               title: 'Backport Approval Not Required',

--- a/src/utils/checks-util.ts
+++ b/src/utils/checks-util.ts
@@ -138,7 +138,10 @@ export async function updateBackportApprovalCheck(
   );
 }
 
-export async function queueBackportApprovalCheck(context: WebHookPRContext) {
+export async function queueBackportApprovalCheck(
+  context: WebHookPRContext,
+  { supersedeCompleted = true }: { supersedeCompleted?: boolean } = {},
+) {
   const pr = context.payload.pull_request;
 
   const output = {
@@ -172,6 +175,22 @@ export async function queueBackportApprovalCheck(context: WebHookPRContext) {
   // would therefore leave a green check that claims to need approval, so
   // create a fresh queued run instead - branch protection only consults
   // the latest run per name, so the new run supersedes the completed one.
+  //
+  // Callers that merely want a pending run to exist (rather than to
+  // invalidate a verdict) pass supersedeCompleted: false - a run that
+  // concluded between the caller's snapshot and this re-fetch was settled
+  // from the live labels by a concurrent delivery, and superseding it would
+  // leave a queued run that no follow-up event ever completes
+  // (electron/electron#53332).
+  if (existingCheck && !supersedeCompleted) {
+    log(
+      'queueBackportApprovalCheck',
+      LogLevel.INFO,
+      `Backport approval check run (${existingCheck.id}) for #${pr.number} already concluded '${existingCheck.conclusion}' - not superseding it`,
+    );
+    return;
+  }
+
   await context.octokit.checks.create(
     context.repo({
       name: BACKPORT_APPROVAL_CHECK,


### PR DESCRIPTION
Fixes the stuck "Backport Approval Enforcement" check on electron/electron#53332.

That PR ended up with five approval check runs on the head SHA. The four from the labeled/unlabeled deliveries all concluded "Not Required" within a minute of the PR opening. The fifth was created at 15:59:41Z by the `opened` handler and never completed, because the `opened` handler is always the slow one for a manual backport (it runs `updateManualBackport` first, which is what writes the labels in the first place). By the time it got to the approval verdict, its check-run snapshot from the top of the handler was two minutes stale, still said `queued`, and so the #423 guard let `queueBackportApprovalCheck` supersede the already-concluded run with a fresh queued one. Nothing fires after that, so it sits there forever. This isn't the reordering edge case #423 was defending against, it's the normal ordering for a manual backport.

Two changes:

- `queueBackportApprovalCheck` takes `{ supersedeCompleted }`. Callers that just need a pending run to exist pass `false`, and if the live run concluded in the meantime it's left alone. The decision is made against the re-fetch right before the write instead of the caller's snapshot. Both the "ensure a run exists" call at the top of the handler and the `opened` stay-pending path use it; the `backport/requested` paths keep superseding, which is the #53035 fix.
- The stay-pending path on `opened` is now only for trop-authored PRs, where the labels really do arrive from a different delivery (`backportImpl`). A manually opened backport gets labeled by `updateManualBackport` in the same handler before the live labels are read, so the verdict is already settled and it concludes right there, no labeled event needed.

Tests: reworked the #423 `opened` specs for the trop-authored case, added the manual-backport case from #53332, and covered `supersedeCompleted: false` in `checks-util.spec.ts`.