### PR TITLE
fix: only delete branch on PR closed, not merged

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,13 +94,17 @@ const probotHandler: ApplicationFunction = async (robot, { getRouter }) => {
     );
     await handleClosedPRLabels(context, pr, change);
 
-    robot.log(`Deleting base branch: ${pr.head.ref}`);
-    try {
-      await context.octokit.git.deleteRef(
-        context.repo({ ref: `heads/${pr.head.ref}` }),
-      );
-    } catch (e) {
-      robot.log('Failed to delete backport branch: ', e);
+    // Merged PRs will automatically delete their head branch, we only
+    // need to clean up after PRs which were closed without merging.
+    if (change === PRChange.CLOSE) {
+      robot.log(`Deleting head branch: ${pr.head.ref}`);
+      try {
+        await context.octokit.git.deleteRef(
+          context.repo({ ref: `heads/${pr.head.ref}` }),
+        );
+      } catch (e) {
+        robot.log('Failed to delete backport branch: ', e);
+      }
     }
   };
 


### PR DESCRIPTION
The logs for Trop are polluted with a lot of "Failed to delete backport branch:" messages because it's attempting to delete the PR branch after merge, which GitHub already does for us automatically, so it's racing and losing. We only need to clean up branches on PRs closed without merging.

I also tweaked a log line from "Deleting base branch" to "Deleting head branch" as the original was inaccurate - base branch is the branch the PR is targeting, which we definitely don't want to delete. 😅 